### PR TITLE
Ensure eval starts with errno zero

### DIFF
--- a/lib/core/evaluation.sh
+++ b/lib/core/evaluation.sh
@@ -16,7 +16,7 @@ shellspec_evaluation_call() {
     shift
     eval set -- shellspec_evaluation_eval ${1+'"$@"'}
   fi
-  [ "${SHELLSPEC_DATA:-}" ] && set -- shellspec_evaluation_with_data "$@"
+  [ ! "${SHELLSPEC_DATA:-}" ] || set -- shellspec_evaluation_with_data "$@"
   "$@" >"$SHELLSPEC_STDOUT_FILE" 2>"$SHELLSPEC_STDERR_FILE" &&:
   shellspec_evaluation_cleanup $?
 }
@@ -41,7 +41,7 @@ shellspec_evaluation_invoke() {
     shift
     eval set -- shellspec_evaluation_eval ${1+'"$@"'}
   fi
-  [ "${SHELLSPEC_DATA:-}" ] && set -- shellspec_evaluation_with_data "$@"
+  [ ! "${SHELLSPEC_DATA:-}" ] || set -- shellspec_evaluation_with_data "$@"
   ( shellspec_around_invoke "$@" ) >"$SHELLSPEC_STDOUT_FILE" 2>"$SHELLSPEC_STDERR_FILE" &&:
   shellspec_evaluation_cleanup $?
 }

--- a/spec/core/evaluation_spec.sh
+++ b/spec/core/evaluation_spec.sh
@@ -40,6 +40,12 @@ Describe "core/evaluation.sh"
       When call 'echo "${*:-}"' 1 2 3
       The stdout should equal '1 2 3'
     End
+
+    It 'ensures errno 0 before evaluating function'
+      relay_errno() { return ${?}; }
+      When call relay_errno
+      The status should equal 0
+    End
   End
 
   Describe 'run evaluation'
@@ -100,6 +106,13 @@ Describe "core/evaluation.sh"
     It 'accepts evaluatable string'
       When invoke 'echo "${*:-}"' 1 2 3
       The stdout should equal '1 2 3'
+    End
+
+    It 'ensures errno 0 before calling external command'
+      shellspec_around_invoke() { "$@"; }
+      relay_errno() { return ${?}; }
+      When invoke relay_errno
+      The status should equal 0
     End
   End
 


### PR DESCRIPTION
I discovered this when I was testing a function which is of the form;

```sh
func() {
  _err=${?}
 ...[stuff here]...
 return ${_err}
}
```
...and I was expecting it to return true (`The status should be success`), but I found that `shellspec_evaluation_call` was always calling the function with `${?}` already set to non-zero. It turns out it is a leftover of the non-empty ("-n") test of `${SHELLSPEC_DATA}` just before the evaluation, so I added the noop `:` to ensure that never happens. If you don't like the aesthetics of a lone ":" on a line by itself it could instead be `true`, as I guess that is usually just aliased to `:` anyway...