### PR TITLE
Remove LF and TAB in specfile

### DIFF
--- a/lib/core/outputs.sh
+++ b/lib/core/outputs.sh
@@ -169,11 +169,11 @@ shellspec_output_SYNTAX_ERROR_PARAM_TYPE() {
 shellspec_output_ABORTED() {
   if [ -s "$SHELLSPEC_STDOUT_FILE" ]; then
     shellspec_readfile SHELLSPEC_STDOUT "$SHELLSPEC_STDOUT_FILE"
-    set -- "$1" "${2:-}stdout:${SHELLSPEC_STDOUT}${LF}"
+    set -- "$1" "${2:-}stdout:${SHELLSPEC_STDOUT}${SHELLSPEC_LF}"
   fi
   if [ -s "$SHELLSPEC_STDERR_FILE" ]; then
     shellspec_readfile SHELLSPEC_STDERR "$SHELLSPEC_STDERR_FILE"
-    set -- "$1" "${2:-}stderr:${SHELLSPEC_STDERR}${LF}"
+    set -- "$1" "${2:-}stderr:${SHELLSPEC_STDERR}${SHELLSPEC_LF}"
   fi
   shellspec_output_statement "tag:bad" "note:" "fail:y" \
     "message:Example aborted (exit status: $1)" "failure_message:${2:-}"

--- a/spec/core/evaluation_spec.sh
+++ b/spec/core/evaluation_spec.sh
@@ -60,7 +60,8 @@ Describe "core/evaluation.sh"
     It 'can not aborts with set -e'
       evaluation() { set -e; echo 1; false; echo 2; }
       When call evaluation
-      The stdout should equal "1${LF}2"
+      The line 1 of stdout should equal "1"
+      The line 2 of stdout should equal "2"
       The status should equal 0
     End
 

--- a/spec/core/matchers/include_spec.sh
+++ b/spec/core/matchers/include_spec.sh
@@ -10,13 +10,13 @@ Describe "core/matchers/include.sh"
     End
 
     It 'matches that include string'
-      subject() { %= "foo${LF}bar${LF}baz"; }
+      subject() { printf 'foo\nbar\nbaz\n'; }
       When run shellspec_matcher_include "bar"
       The status should be success
     End
 
     It 'does not matches that not include string'
-      subject() { %= "foo${LF}BAR${LF}baz"; }
+      subject() { printf 'foo\nBAR\nbaz\n'; }
       When run shellspec_matcher_include "bar"
       The status should be failure
     End
@@ -28,13 +28,13 @@ Describe "core/matchers/include.sh"
     End
 
     It 'outputs error if parameters is missing'
-      subject() { %= "foo${LF}bar${LF}baz"; }
+      subject() { printf 'foo\nbar\nbaz\n'; }
       When run shellspec_matcher_include
       The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
     End
 
     It 'outputs error if parameters count is invalid'
-      subject() { %= "foo${LF}bar${LF}baz"; }
+      subject() { printf 'foo\nbar\nbaz\n'; }
       When run shellspec_matcher_include "foo" "bar"
       The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
     End

--- a/spec/core/modifiers/contents_spec.sh
+++ b/spec/core/modifiers/contents_spec.sh
@@ -39,15 +39,15 @@ Describe "core/modifiers/contents.sh"
 
   Describe "entire contents modifier"
     Example 'example'
-      The entire contents of file "$FILE" should equal "a${LF}${LF}"
-      The entire contents of the file "$FILE" should equal "a${LF}${LF}"
-      The file "$FILE" entire contents should equal "a${LF}${LF}"
+      The entire contents of file "$FILE" should equal "a${IFS%?}${IFS%?}"
+      The entire contents of the file "$FILE" should equal "a${IFS%?}${IFS%?}"
+      The file "$FILE" entire contents should equal "a${IFS%?}${IFS%?}"
     End
 
     It 'reads the entire contents of the file when file exists'
       subject() { %- "$FILE"; }
       When run shellspec_modifier_entire_contents _modifier_
-      The entire stdout should equal "a${LF}${LF}"
+      The entire stdout should equal "a${IFS%?}${IFS%?}"
     End
 
     It 'can not reads the entire contents of the file when file not exists'

--- a/spec/core/modifiers/line_spec.sh
+++ b/spec/core/modifiers/line_spec.sh
@@ -9,37 +9,37 @@ Describe "core/modifiers/line.sh"
     End
 
     It 'gets the first line'
-      subject() { %- "foo"; }
+      subject() { printf 'foo'; }
       When run shellspec_modifier_line 1 _modifier_
       The entire stdout should equal foo
     End
 
     It 'gets the specified line'
-      subject() { %- "foo${LF}bar${LF}baz"; }
+      subject() { printf 'foo\nbar\nbaz'; }
       When run shellspec_modifier_line 2 _modifier_
       The entire stdout should equal bar
     End
 
     It 'gets undefined when missing line'
-      subject() { %- "foo${LF}"; }
+      subject() { printf 'foo\n'; }
       When run shellspec_modifier_line 2 _modifier_
       The status should be failure
     End
 
     It 'gets the specified empty line'
-      subject() { %- "foo${LF}${LF}"; }
+      subject() { printf 'foo\n\n'; }
       When run shellspec_modifier_line 2 _modifier_
       The entire stdout should equal ""
     End
 
     It 'can not get the first line when subject is empty'
-      subject() { %- ""; }
+      subject() { printf ''; }
       When run shellspec_modifier_line 1 _modifier_
       The status should be failure
     End
 
     It 'gets the first line as "" when subject is "<LF>"'
-      subject() { %- "${LF}"; }
+      subject() { printf '\n'; }
       When run shellspec_modifier_line 1 _modifier_
       The entire stdout should equal ""
     End
@@ -51,19 +51,19 @@ Describe "core/modifiers/line.sh"
     End
 
     It 'outputs error if value is not a number'
-      subject() { %- "foo"; }
+      subject() { printf 'foo'; }
       When run shellspec_modifier_line ni
       The stderr should equal SYNTAX_ERROR_PARAM_TYPE
     End
 
     It 'outputs error if value is missing'
-      subject() { %- "foo"; }
+      subject() { printf 'foo'; }
       When run shellspec_modifier_line
       The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
     End
 
     It 'outputs error if next word is missing'
-      subject() { %- "foo"; }
+      subject() { printf 'foo'; }
       When run shellspec_modifier_line 2
       The stderr should equal SYNTAX_ERROR_DISPATCH_FAILED
     End

--- a/spec/core/modifiers/lines_spec.sh
+++ b/spec/core/modifiers/lines_spec.sh
@@ -15,19 +15,19 @@ Describe "core/modifiers/lines.sh"
     End
 
     It 'counts as 2 lines when subject is "foo<LF>bar<LF>" (with last LF)'
-      subject() { %= "foo${LF}bar"; }
+      subject() { printf 'foo\nbar\n'; }
       When run shellspec_modifier_lines _modifier_
       The stdout should equal 2
     End
 
     It 'counts as 2 lines when subject is "foo<LF>bar" (without last LF)'
-      subject() { %- "foo${LF}bar"; }
+      subject() { printf 'foo\nbar'; }
       When run shellspec_modifier_lines _modifier_
       The stdout should equal 2
     End
 
     It 'counts as 3 lines when subject is "foo<LF>bar<LF><LF>"'
-      subject() { %= "foo${LF}bar${LF}"; }
+      subject() { printf 'foo\nbar\n\n'; }
       When run shellspec_modifier_lines _modifier_
       The stdout should equal 3
     End
@@ -45,7 +45,7 @@ Describe "core/modifiers/lines.sh"
     End
 
     It 'outputs error if next word is missing'
-      subject() { %= "foo${LF}bar"; }
+      subject() { printf 'foo\nbar\n'; }
       When run shellspec_modifier_lines
       The stderr should equal SYNTAX_ERROR_DISPATCH_FAILED
     End

--- a/spec/core/modifiers/word_spec.sh
+++ b/spec/core/modifiers/word_spec.sh
@@ -9,7 +9,7 @@ Describe "core/modifiers/word.sh"
     End
 
     It 'gets the specified word'
-      subject() { %- "foo  bar $TAB baz $LF qux"; }
+      subject() { printf 'foo  bar \t baz \n qux'; }
       When run shellspec_modifier_word 4 _modifier_
       The stdout should equal qux
     End
@@ -21,19 +21,19 @@ Describe "core/modifiers/word.sh"
     End
 
     It 'outputs error if value is not a number'
-      subject() { %- "foo  bar $TAB baz $LF qux"; }
+      subject() { printf 'foo  bar \t baz \n qux'; }
       When run shellspec_modifier_word ni _modifier_
       The stderr should equal SYNTAX_ERROR_PARAM_TYPE
     End
 
     It 'outputs error if value is missing'
-      subject() { %- "foo  bar $TAB baz $LF qux"; }
+      subject() { printf 'foo  bar \t baz \n qux'; }
       When run shellspec_modifier_word
       The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
     End
 
     It 'outputs error if next word is missing'
-      subject() { %- "foo  bar $TAB baz $LF qux"; }
+      subject() { printf 'foo  bar \t baz \n qux'; }
       When run shellspec_modifier_word 2
       The stderr should equal SYNTAX_ERROR_DISPATCH_FAILED
     End

--- a/spec/core/subjects/stderr_spec.sh
+++ b/spec/core/subjects/stderr_spec.sh
@@ -12,7 +12,7 @@ Describe "core/subjects/stderr.sh"
     End
 
     It 'uses stderr as subject when stderr is defined'
-      stderr() { %= "test"; }
+      stderr() { echo "test"; }
       When run shellspec_subject_stderr _modifier_
       The entire stdout should equal 'test'
     End
@@ -24,7 +24,7 @@ Describe "core/subjects/stderr.sh"
     End
 
     It 'outputs error if next word is missing'
-      stderr() { %= "test"; }
+      stderr() { echo "test"; }
       When run shellspec_subject_stderr
       The entire stderr should equal SYNTAX_ERROR_DISPATCH_FAILED
     End
@@ -34,14 +34,14 @@ Describe "core/subjects/stderr.sh"
     Example 'example'
       func() { echo "foo" >&2; }
       When call func
-      The entire stderr should equal "foo${LF}"
-      The entire error should equal "foo${LF}"
+      The entire stderr should equal "foo${IFS%?}"
+      The entire error should equal "foo${IFS%?}"
     End
 
     It 'uses stderr including last LF as subject when stderr is defined'
-      stderr() { %= "test"; }
+      stderr() { echo "test"; }
       When run shellspec_subject_entire_stderr _modifier_
-      The entire stdout should equal "test${LF}"
+      The entire stdout should equal "test${IFS%?}"
     End
 
     It 'uses undefined as subject when stderr is undefined'
@@ -51,7 +51,7 @@ Describe "core/subjects/stderr.sh"
     End
 
     It 'outputs error if next word is missing'
-      stderr() { %= "test"; }
+      stderr() { echo "test"; }
       When run shellspec_subject_entire_stderr
       The entire stderr should equal SYNTAX_ERROR_DISPATCH_FAILED
     End

--- a/spec/core/subjects/stdout_spec.sh
+++ b/spec/core/subjects/stdout_spec.sh
@@ -12,7 +12,7 @@ Describe "core/subjects/stdout.sh"
     End
 
     It "uses stdout as subject when stdout is defined"
-      stdout() { %= "test"; }
+      stdout() { echo "test"; }
       When run shellspec_subject_stdout _modifier_
       The entire stdout should equal 'test'
     End
@@ -24,7 +24,7 @@ Describe "core/subjects/stdout.sh"
     End
 
     It 'outputs error if next word is missing'
-      stdout() { %= "test"; }
+      stdout() { echo "test"; }
       When run shellspec_subject_stdout
       The entire stderr should equal SYNTAX_ERROR_DISPATCH_FAILED
     End
@@ -34,14 +34,14 @@ Describe "core/subjects/stdout.sh"
     Example 'example'
       func() { echo "foo"; }
       When call func
-      The entire stdout should equal "foo${LF}"
-      The entire output should equal "foo${LF}" # alias for entire stdout
+      The entire stdout should equal "foo${IFS%?}"
+      The entire output should equal "foo${IFS%?}"
     End
 
     It "uses stdout including last LF as subject when stdout is defined"
-      stdout() { %= "test"; }
+      stdout() { echo "test"; }
       When run shellspec_subject_entire_stdout _modifier_
-      The entire stdout should equal "test${LF}"
+      The entire stdout should equal "test${IFS%?}"
     End
 
     It "uses undefined as subject when stdout is undefined"
@@ -51,7 +51,7 @@ Describe "core/subjects/stdout.sh"
     End
 
     It 'output error if next word is missing'
-      stdout() { %= "test"; }
+      stdout() { echo "test"; }
       When run shellspec_subject_entire_stdout
       The entire stderr should equal SYNTAX_ERROR_DISPATCH_FAILED
     End

--- a/spec/core/subjects/variable_spec.sh
+++ b/spec/core/subjects/variable_spec.sh
@@ -12,10 +12,10 @@ Describe "core/subjects/variable.sh"
     End
 
     Context 'when the variable exists'
-      Before 'var="test${LF}"'
+      Before "var='test${IFS%?}'"
       It 'uses the value of variable as subject'
         When run shellspec_subject variable var _modifier_
-        The entire stdout should equal "test${LF}"
+        The entire stdout should equal "test${IFS%?}"
       End
     End
 

--- a/spec/core/utils_spec.sh
+++ b/spec/core/utils_spec.sh
@@ -88,7 +88,7 @@ Describe "core/utils.sh"
       func() { %= "ok"; }
       It 'captures "ok<LF>"'
         When call shellspec_capture var func
-        The variable var should equal "ok${LF}"
+        The variable var should equal "ok${IFS%?}"
       End
     End
 

--- a/spec/general_spec.sh
+++ b/spec/general_spec.sh
@@ -158,7 +158,9 @@ Describe "general.sh"
 
     It 'calls callback with index and value'
       When call shellspec_each callback a b c
-      The stdout should equal "a:1:3${LF}b:2:3${LF}c:3:3"
+      The line 1 of stdout should equal "a:1:3"
+      The line 2 of stdout should equal "b:2:3"
+      The line 3 of stdout should equal "c:3:3"
     End
 
     It 'calls callback with no params'
@@ -245,30 +247,30 @@ Describe "general.sh"
   Describe 'shellspec_putsn()'
     It 'does not output anything without arguments'
       When call shellspec_putsn
-      The entire stdout should equal "${LF}"
+      The entire stdout should equal "${IFS%?}"
     End
 
     It 'outputs append with LF'
       When call shellspec_putsn "a"
-      The entire stdout should equal "a${LF}"
+      The entire stdout should equal "a${IFS%?}"
     End
 
     It 'joins arguments with space and outputs append with LF'
       When call shellspec_putsn "a" "b"
-      The entire stdout should equal "a b${LF}"
+      The entire stdout should equal "a b${IFS%?}"
     End
 
     It 'outputs with raw string append with LF'
       When call shellspec_putsn 'a\b'
-      The entire stdout should equal "a\\b${LF}"
+      The entire stdout should equal "a\\b${IFS%?}"
       The length of entire stdout should equal 4
     End
 
     Context 'when change IFS'
-      Before 'IFS=@'
       It 'joins arguments with spaces'
-        When call shellspec_putsn a b c
-        The entire stdout should equal "a b c${LF}"
+        BeforeRun 'IFS=@'
+        When run shellspec_putsn a b c
+        The entire stdout should equal "a b c${IFS%?}"
       End
     End
   End
@@ -304,17 +306,17 @@ Describe "general.sh"
     End
 
     It 'calls callback by each line'
-      When call shellspec_lines callback "a${LF}b"
+      When call shellspec_lines callback "a${IFS%?}b"
       The stdout should eq "1:a 2:b "
     End
 
     It 'ignores last LF'
-      When call shellspec_lines callback "a${LF}b${LF}"
+      When call shellspec_lines callback "a${IFS%?}b${IFS%?}"
       The stdout should eq "1:a 2:b "
     End
 
     It 'can cancels calls of callback.'
-      When call shellspec_lines callback_with_cancel "a${LF}b"
+      When call shellspec_lines callback_with_cancel "a${IFS%?}b"
       The stdout should eq "1:a "
     End
   End
@@ -366,18 +368,13 @@ Describe "general.sh"
   Describe 'shellspec_readfile()'
     It 'reads the file as is'
       When call shellspec_readfile var "$FIXTURE/end-with-multiple-lf.txt"
-      The variable var should equal "a${LF}${LF}"
+      The variable var should equal "a${IFS%?}${IFS%?}"
     End
   End
 
   Describe "shellspec_trim()"
-    It 'trims space'
-      When call shellspec_trim value "  abc  "
-      The value "$value" should eq 'abc'
-    End
-
-    It 'trims tab'
-      When call shellspec_trim value "${TAB}${TAB}abc${TAB}${TAB}"
+    It 'trims white space'
+      When call shellspec_trim value " $IFS abc $IFS "
       The value "$value" should eq 'abc'
     End
   End
@@ -493,7 +490,7 @@ Describe "general.sh"
   End
 
   Describe "shellspec_chomp()"
-    Before 'var="string${LF}${LF}${LF}"'
+    Before "var='string${IFS%?}${IFS%?}${IFS%?}'"
     It "removes trailing LF"
       When call shellspec_chomp var
       The variable var should eq "string"

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -62,9 +62,6 @@ shellspec_spec_helper_configure() {
   switch_on() { shellspec_if "$SHELLSPEC_SUBJECT"; }
   switch_off() { shellspec_unless "$SHELLSPEC_SUBJECT"; }
 
-  # shellcheck disable=SC2034
-  LF="$SHELLSPEC_LF" TAB="$SHELLSPEC_TAB"
-
   posh_pattern_matching_bug() {
     # shellcheck disable=SC2194
     case "a[d]" in (*"a[d]"*) false; esac # posh <= 0.12.6


### PR DESCRIPTION
Shellspec failed unexpectedly due to using LF in specfile.

Fixes #31