### PR TITLE
Add new match pattern matcher

### DIFF
--- a/lib/core/matchers/match.sh
+++ b/lib/core/matchers/match.sh
@@ -3,6 +3,17 @@
 shellspec_syntax 'shellspec_matcher_match'
 
 shellspec_matcher_match() {
+  if [ "${1:-}" = "pattern" ]; then
+    shift
+    eval shellspec_matcher_match_pattern ${1+'"$@"'}
+    return $?
+  fi
+
+  shellspec_syntax_param count [ $# -eq 1 ] || return 0
+  shellspec_matcher_old_match "$@"
+}
+
+shellspec_matcher_old_match() {
   shellspec_matcher__match() {
     # shellcheck disable=SC2034
     SHELLSPEC_EXPECT=$1
@@ -16,6 +27,26 @@ shellspec_matcher_match() {
 
   shellspec_matcher__failure_message_when_negated() {
     shellspec_putsn "expected $1 not to match $2"
+  }
+
+  shellspec_syntax_param count [ $# -eq 1 ] || return 0
+  shellspec_matcher_do_match "$@"
+}
+
+shellspec_matcher_match_pattern() {
+  shellspec_matcher__match() {
+    # shellcheck disable=SC2034
+    SHELLSPEC_EXPECT=$1
+    [ "${SHELLSPEC_SUBJECT+x}" ] || return 1
+    shellspec_match_pattern "$SHELLSPEC_SUBJECT" "$1"
+  }
+
+  shellspec_matcher__failure_message() {
+    shellspec_putsn "expected $1 to match pattern $2"
+  }
+
+  shellspec_matcher__failure_message_when_negated() {
+    shellspec_putsn "expected $1 not to match pattern $2"
   }
 
   shellspec_syntax_param count [ $# -eq 1 ] || return 0

--- a/lib/core/matchers/match.sh
+++ b/lib/core/matchers/match.sh
@@ -9,11 +9,12 @@ shellspec_matcher_match() {
     return $?
   fi
 
+  shellspec_deprecated "'match' matcher deprecated, use 'match pattern' matcher instead"
   shellspec_syntax_param count [ $# -eq 1 ] || return 0
-  shellspec_matcher_old_match "$@"
+  shellspec_matcher_deprecated_match "$@"
 }
 
-shellspec_matcher_old_match() {
+shellspec_matcher_deprecated_match() {
   shellspec_matcher__match() {
     # shellcheck disable=SC2034
     SHELLSPEC_EXPECT=$1

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -409,6 +409,10 @@ shellspec_match() {
   [ "${2:-}" ] && eval "case \${1:-} in ($2) true ;; (*) false ;; esac &&:"
 }
 
+shellspec_match_pattern() {
+  [ "${2:-}" ] && eval "case \${1:-} in ($2) true ;; (*) false ;; esac &&:"
+}
+
 shellspec_join() {
   IFS=" $IFS"
   eval "shift; $1=\${*:-}"

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -405,12 +405,24 @@ if ! shellspec_ends_with_backslash "\\"; then
   }
 fi
 
+# shellspec_match() deprecated
 shellspec_match() {
   [ "${2:-}" ] && eval "case \${1:-} in ($2) true ;; (*) false ;; esac &&:"
 }
 
 shellspec_match_pattern() {
-  [ "${2:-}" ] && eval "case \${1:-} in ($2) true ;; (*) false ;; esac &&:"
+  [ "${2:-}" ] || return 1
+  shellspec_match_pattern=$2
+  set -- \\ \" \# \$ \& \' \( \) \; \< \> \` \~ '=' '^' "$SHELLSPEC_TAB" "$1"
+  while [ $# -gt 1 ]; do
+    shellspec_replace shellspec_match_pattern "$1" "\\$1"
+    shift
+  done
+  shellspec_replace shellspec_match_pattern " " '" "'
+  shellspec_replace shellspec_match_pattern "$SHELLSPEC_LF" '"$SHELLSPEC_LF"'
+  shellspec_replace shellspec_match_pattern "$SHELLSPEC_CR" '"$SHELLSPEC_CR"'
+  shellspec_replace shellspec_match_pattern "$SHELLSPEC_VT" '"$SHELLSPEC_VT"'
+  eval "case \$1 in ($shellspec_match_pattern) true ;; (*) false ;; esac &&:" 2>/dev/null
 }
 
 shellspec_join() {

--- a/lib/libexec/translator.sh
+++ b/lib/libexec/translator.sh
@@ -2,7 +2,7 @@
 
 # shellcheck source=lib/libexec.sh
 . "${SHELLSPEC_LIB:-./lib}/libexec.sh"
-use constants trim match ends_with_backslash
+use constants trim match_pattern ends_with_backslash
 load grammar
 
 initialize() {
@@ -25,7 +25,7 @@ check_filter() {
   escape_one_line_syntax escaped_syntax "$1"
   eval "set -- $escaped_syntax"
   if [ $# -gt 0 ]; then
-    match "$1" "$SHELLSPEC_EXAMPLE_FILTER" && return 0
+    match_pattern "$1" "$SHELLSPEC_EXAMPLE_FILTER" && return 0
     shift
   fi
   [ "$SHELLSPEC_TAG_FILTER" ] || return 1

--- a/spec/core/matchers/match_spec.sh
+++ b/spec/core/matchers/match_spec.sh
@@ -3,7 +3,7 @@
 Describe "core/matchers/match.sh"
   BeforeRun set_subject matcher_mock
 
-  Describe 'match matcher'
+  Describe 'match (old) matcher'
     Example 'example'
       The value "foobarbaz" should match "foo*"
       The value "foobarbaz" should not match "FOO*"
@@ -30,6 +30,49 @@ Describe "core/matchers/match.sh"
     It 'outputs error if parameters is missing'
       subject() { %- "foobarbaz"; }
       When run shellspec_matcher_match
+      The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
+    End
+
+    It 'outputs error if parameters count is invalid'
+      subject() { %- "foobarbaz"; }
+      When run shellspec_matcher_match "foo" "bar"
+      The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
+    End
+  End
+
+  Describe 'match pattern matcher'
+    Example 'example'
+      The value "foobarbaz" should match pattern "foo*"
+      The value "foobarbaz" should not match pattern "FOO*"
+    End
+
+    It 'match a string containing a pattern'
+      subject() { %- "foobarbaz"; }
+      When run shellspec_matcher_match "foo*"
+      The status should be success
+    End
+
+    It 'does not match a string not containing a pattern'
+      subject() { %- "foobarbaz"; }
+      When run shellspec_matcher_match pattern "FOO*"
+      The status should be failure
+    End
+
+    It 'does not match undefined'
+      subject() { false; }
+      When run shellspec_matcher_match pattern "*"
+      The status should be failure
+    End
+
+    It 'outputs error if parameters is missing'
+      subject() { %- "foobarbaz"; }
+      When run shellspec_matcher_match
+      The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
+    End
+
+    It 'outputs error if pattern is missing'
+      subject() { %- "foobarbaz"; }
+      When run shellspec_matcher_match pattern
       The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
     End
 

--- a/spec/core/matchers/match_spec.sh
+++ b/spec/core/matchers/match_spec.sh
@@ -3,7 +3,7 @@
 Describe "core/matchers/match.sh"
   BeforeRun set_subject matcher_mock
 
-  Describe 'match (old) matcher'
+  Describe 'match (deprecated) matcher'
     Example 'example'
       The value "foobarbaz" should match "foo*"
       The value "foobarbaz" should not match "FOO*"

--- a/spec/general_spec.sh
+++ b/spec/general_spec.sh
@@ -420,7 +420,7 @@ Describe "general.sh"
     End
   End
 
-  Describe "shellspec_match()"
+  Describe "shellspec_match() (deprecated)"
     It 'returns success if value mactches with pattern'
       When call shellspec_match foo "[fF]?*"
       The status should be success
@@ -429,6 +429,36 @@ Describe "general.sh"
     It 'returns failure if value mactches with pattern'
       When call shellspec_match bar "[fF]?*"
       The status should be failure
+    End
+  End
+
+  Describe "shellspec_match_pattern()"
+    It 'can use shell script pattern'
+      When call shellspec_match_pattern foobar "[fF]??b*"
+      The status should be success
+    End
+
+    It 'can use negative pattern'
+      When call shellspec_match_pattern foobar "[!fF]??b*"
+      The status should be failure
+    End
+
+    It 'can use OR'
+      When call shellspec_match_pattern foo "foo|bar"
+      The status should be success
+    End
+
+    It 'escapes symbol internally to avoid syntax error'
+      string() { echo "!\"#\$%&'()-=^~\\@\`{;+:},<.>/\_"; }
+      When call shellspec_match_pattern "$(string)" "$(string)"
+      The status should be success
+    End
+
+    It 'escapes spaces internally to avoid syntax error'
+      # Do not modify this string
+      string() { printf "= \b = \f = \n = \r = \t = \v = "; }
+      When call shellspec_match_pattern "$(string)" "$(string)"
+      The status should be success
     End
   End
 


### PR DESCRIPTION
- `match` matcher deprecated, use `match pattern` matcher instead
- Fix --example option

Fixes #28