### PR TITLE
Improve result modifier

### DIFF
--- a/lib/core/modifiers/result.sh
+++ b/lib/core/modifiers/result.sh
@@ -4,7 +4,8 @@ shellspec_syntax 'shellspec_modifier_result'
 
 shellspec_modifier_result() {
   if [ "${SHELLSPEC_SUBJECT+x}" ]; then
-    if ! SHELLSPEC_SUBJECT=$($SHELLSPEC_SUBJECT 2>&1); then
+    shellspec_off UNHANDLED_STDOUT UNHANDLED_STDERR UNHANDLED_STATUS
+    if ! SHELLSPEC_SUBJECT=$(shellspec_modifier_result_invoke 2>&1); then
       unset SHELLSPEC_SUBJECT ||:
     fi
   else
@@ -12,4 +13,9 @@ shellspec_modifier_result() {
   fi
 
   eval shellspec_syntax_dispatch modifier ${1+'"$@"'}
+}
+
+shellspec_modifier_result_invoke() {
+  set -- "$SHELLSPEC_SUBJECT"
+  "$@" "${SHELLSPEC_STDOUT:-}" "${SHELLSPEC_STDERR:-}" "${SHELLSPEC_STATUS:-}"
 }

--- a/lib/core/modifiers/result.sh
+++ b/lib/core/modifiers/result.sh
@@ -4,6 +4,11 @@ shellspec_syntax 'shellspec_modifier_result'
 
 shellspec_modifier_result() {
   if [ "${SHELLSPEC_SUBJECT+x}" ]; then
+    if ! shellspec_is_function "$SHELLSPEC_SUBJECT"; then
+      shellspec_output SYNTAX_ERROR "'$SHELLSPEC_SUBJECT' is not function name"
+      return 0
+    fi
+
     shellspec_off UNHANDLED_STDOUT UNHANDLED_STDERR UNHANDLED_STATUS
     if ! SHELLSPEC_SUBJECT=$(shellspec_modifier_result_invoke 2>&1); then
       unset SHELLSPEC_SUBJECT ||:

--- a/lib/core/utils.sh
+++ b/lib/core/utils.sh
@@ -9,11 +9,15 @@ shellspec_get_nth() {
 shellspec_is() {
   case $1 in
     number) case ${2:-} in ( '' | *[!0-9]* ) return 1; esac ;;
-    funcname)
-      case ${2:-} in ([a-zA-Z_]*) ;; (*) return 1; esac
-      case ${2:-} in (*[!a-zA-Z0-9_]*) return 1; esac ;;
+    funcname) shellspec_is_function "${2:-}" || return 1 ;;
     *) shellspec_error "shellspec_is: invalid type name '$1'"
   esac
+  return 0
+}
+
+shellspec_is_function() {
+  case ${1:-} in ([a-zA-Z_]*) ;; (*) return 1; esac
+  case ${1:-} in (*[!a-zA-Z0-9_]*) return 1; esac
   return 0
 }
 

--- a/spec/core/modifiers/result_spec.sh
+++ b/spec/core/modifiers/result_spec.sh
@@ -12,6 +12,20 @@ Describe "core/modifiers/result.sh"
       The result of 'bar()' should equal ok # also capture stderr
     End
 
+    Describe 'example with stdout, stderr and status'
+      foo() { echo stdout; echo stderr >&2; return 123; }
+      get_stdout() { echo "$1"; }
+      get_stderr() { echo "$2"; }
+      get_status() { echo "$3"; }
+
+      It "retrives result of evaluation"
+        When call foo
+        The result of 'get_stdout()' should equal "stdout"
+        The result of 'get_stderr()' should equal "stderr"
+        The result of 'get_status()' should equal 123
+      End
+    End
+
     It 'gets stdout and stderr when subject is function that returns success'
       subject() { %- "success_with_output"; }
       success_with_output() { echo stdout; echo stderr >&2; true; }

--- a/spec/core/modifiers/result_spec.sh
+++ b/spec/core/modifiers/result_spec.sh
@@ -48,6 +48,12 @@ Describe "core/modifiers/result.sh"
       The status should be failure
     End
 
+    It 'outputs error if invalid function name specified'
+      subject() { %- "foo -a"; }
+      When run shellspec_modifier_result
+      The stderr should equal SYNTAX_ERROR
+    End
+
     It 'outputs error if next modifier is missing'
       subject() { %- "success_with_stdout"; }
       success_with_stdout() { echo ok; true; }


### PR DESCRIPTION
- Add function name check 
- Pass stdout, stderr, status as arguments

result examples

```sh
get_version() {
  # The result of the evaluation is passed as arguments
  # $1: stdout, $2: stderr, $3: status
  echo "$1" | grep -o '[0-9.]*' | head -1
}

When call echo "GNU bash, version 4.4.20(1)-release (x86_64-pc-linux-gnu)"
The result of function get_version should equal "4.4.20"
The result of "get_version()" should equal "4.4.20" # shorthand
```

Fixes #30 
