### PR TITLE
Improve satisfy matcher

### DIFF
--- a/lib/core/matchers/satisfy.sh
+++ b/lib/core/matchers/satisfy.sh
@@ -2,11 +2,36 @@
 
 shellspec_syntax 'shellspec_matcher_satisfy'
 
+SHELLSPEC_SATISFY_STDOUT_FILE="$SHELLSPEC_TMPBASE/$$.satisfy.stdout"
+SHELLSPEC_SATISFY_STDERR_FILE="$SHELLSPEC_TMPBASE/$$.satisfy.stderr"
+
 shellspec_matcher_satisfy() {
   shellspec_matcher__match() {
+    if ! shellspec_is_function "${1:-}"; then
+      shellspec_output SYNTAX_ERROR "'$1' is not function name"
+      return 0
+    fi
+
     # shellcheck disable=SC2034
-    SHELLSPEC_EXPECT="$*"
-    "$@"
+    IFS=" $IFS" && SHELLSPEC_EXPECT="$*" && IFS=${IFS#?}
+    ( if shellspec_is_identifier "$1"; then
+        if [ "${SHELLSPEC_SUBJECT+x}" ]; then
+          eval "$1=\$SHELLSPEC_SUBJECT"
+        else
+          unset "$1" ||:
+        fi
+      fi
+      "$@"
+    ) >"$SHELLSPEC_SATISFY_STDOUT_FILE" 2>"$SHELLSPEC_SATISFY_STDERR_FILE" &&:
+
+    set -- "$?"
+    if [ -s "$SHELLSPEC_SATISFY_STDOUT_FILE" ]; then
+      shellspec_output SATISFY_WARN "$1" "$SHELLSPEC_SATISFY_STDOUT_FILE"
+    fi
+    if [ -s "$SHELLSPEC_SATISFY_STDERR_FILE" ]; then
+      shellspec_output SATISFY_ERROR "$1" "$SHELLSPEC_SATISFY_STDERR_FILE"
+    fi
+    return "$1"
   }
 
   shellspec_matcher__failure_message() {

--- a/lib/core/outputs.sh
+++ b/lib/core/outputs.sh
@@ -172,6 +172,23 @@ shellspec_output_RESULT_ERROR() {
     "message:${SHELLSPEC_EXPECTATION:-}" "failure_message:$1$2"
 }
 
+shellspec_output_SATISFY_WARN() {
+  shellspec_readfile SHELLSPEC_SATISFY_WARN "$2"
+  set -- "satisfy matcher unexpected output (exit status: $1)${SHELLSPEC_LF}" \
+    "$SHELLSPEC_SATISFY_WARN${SHELLSPEC_LF}"
+  shellspec_output_statement "tag:warn" "note:WARNING" \
+    "fail:${SHELLSPEC_WARNING_AS_FAILURE:+y}" \
+    "message:${SHELLSPEC_EXPECTATION:-}" "failure_message:$1$2"
+}
+
+shellspec_output_SATISFY_ERROR() {
+  shellspec_readfile SHELLSPEC_SATISFY_ERROR "$2"
+  set -- "satisfy matcher error (exit status: $1)${SHELLSPEC_LF}" \
+    "$SHELLSPEC_SATISFY_ERROR${SHELLSPEC_LF}"
+  shellspec_output_statement "tag:bad" "note:" "fail:y" \
+    "message:${SHELLSPEC_EXPECTATION:-}" "failure_message:$1$2"
+}
+
 shellspec_output_ABORTED() {
   if [ -s "$SHELLSPEC_STDOUT_FILE" ]; then
     shellspec_readfile SHELLSPEC_STDOUT "$SHELLSPEC_STDOUT_FILE"

--- a/lib/core/utils.sh
+++ b/lib/core/utils.sh
@@ -21,6 +21,12 @@ shellspec_is_function() {
   return 0
 }
 
+shellspec_is_identifier() {
+  case ${1:-} in ([a-zA-Z_]*) ;; (*) return 1; esac
+  case ${1:-} in (*[!a-zA-Z0-9_]*) return 1; esac
+  return 0
+}
+
 shellspec_capture() {
   SHELLSPEC_EVAL="
     if $1=\"\$($2 && echo _)\"; then $1=\${$1%_}; else unset $1 ||:; fi

--- a/sample/spec/11.matcher_spec.sh
+++ b/sample/spec/11.matcher_spec.sh
@@ -106,10 +106,10 @@ Describe 'matcher sample'
   End
 
   Describe 'satisfy matcher'
-    greater_than() { [ "$SHELLSPEC_SUBJECT" -gt "$1" ]; }
+    value() { return $(($@)); }
 
     It 'checks if satisfy condition'
-      The value 10 should satisfy greater_than 5
+      The value 10 should satisfy "value >= 5"
     End
   End
 End

--- a/spec/core/matchers/satisfy_spec.sh
+++ b/spec/core/matchers/satisfy_spec.sh
@@ -4,23 +4,50 @@ Describe "core/matchers/satisfy.sh"
   BeforeRun set_subject matcher_mock
 
   Describe 'satisfy matcher'
-    greater_than() { [ "$SHELLSPEC_SUBJECT" -gt "$1" ]; }
+    greater_than() { [ "${greater_than:?}" -gt "$1" ]; }
 
     Example 'example'
       The value 10 should satisfy greater_than 5
       The value 10 should not satisfy greater_than 20
     End
 
-    It 'matches when satisfies condition'
+    It 'calls function with subject and arguments'
       subject() { %- 10; }
       When run shellspec_matcher_satisfy greater_than 5
       The status should be success
     End
 
-    It 'does not match when not satisfies condition'
+    It 'calls function with undefined subject and arguments'
+      subject() { false; }
+      When run shellspec_matcher_satisfy greater_than 5
+      The stderr should be present
+      The status should be failure
+    End
+
+    It 'should be failure when satisfies condition fails'
       subject() { %- 10; }
       When run shellspec_matcher_satisfy greater_than 20
       The status should be failure
+    End
+
+    It 'outputs SATISFY_WARN if satisfy function echo to stdout'
+      echo_stdout() { echo stdout; }
+      subject() { %- 10; }
+      When run shellspec_matcher_satisfy echo_stdout
+      The stderr should equal SATISFY_WARN
+    End
+
+    It 'outputs SATISFY_ERROR if satisfy function echo to stdout'
+      echo_stderr() { echo stderr >&2; }
+      subject() { %- 10; }
+      When run shellspec_matcher_satisfy echo_stderr
+      The stderr should equal SATISFY_ERROR
+    End
+
+    It 'outputs error if invalid function name specified'
+      subject() { %- 10; }
+      When run shellspec_matcher_satisfy greater-than 20
+      The stderr should equal SYNTAX_ERROR
     End
 
     It 'outputs error if parameters is missing'


### PR DESCRIPTION
- Add function name check
- The subject is stored in the same variable name as the function name

satisfy examples

```sh
value() {
  # The subject is stored in the same variable name as the function name
  test "${value:?}" "$1" "$2"
}

formula() {
  value=${fomula:?}
  [ $(($1)) -eq 1 ]
}

When call echo "50"
The output should satisfy value -gt 10
The output should satisfy formula "10 <= value && value <= 100"
```
