### PR TITLE
errexit workaround

### DIFF
--- a/lib/core/dsl.sh
+++ b/lib/core/dsl.sh
@@ -131,7 +131,7 @@ shellspec_invoke_example() {
   shellspec_off UNHANDLED_STATUS UNHANDLED_STDOUT UNHANDLED_STDERR
 
   # Output SKIP message if skipped in outer group.
-  shellspec_output_if SKIP || {
+  if ! shellspec_output_if SKIP; then
     "${SHELLSPEC_SHELL_OPTION:-eval}" "${SHELLSPEC_SHELL_OPTIONS:-:}"
     if ! shellspec_call_before_hooks EACH; then
       SHELLSPEC_LINENO=$SHELLSPEC_LINENO_BEGIN-$SHELLSPEC_LINENO_END
@@ -150,7 +150,7 @@ shellspec_invoke_example() {
       shellspec_output FAILED
       return 0
     fi
-  }
+  fi
 
   shellspec_if SKIP && shellspec_unless FAILED && {
     shellspec_output SKIPPED && return 0

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -74,25 +74,20 @@ shellspec_import() {
 }
 
 shellspec_import_deep() {
-  shellspec_import_ "${1%%:*}" "$2" && return 0
+  if [ -e "${1%%:*}/$2.sh" ]; then
+    # shellcheck disable=SC1090
+    . "${1%%:*}/$2.sh"
+    return 0
+  fi
+  if [ -e "${1%%:*}/$2/$2.sh" ]; then
+    # shellcheck disable=SC1090
+    . "${1%%:*}/$2/$2.sh"
+    return 0
+  fi
   case $1 in
     *:*) shellspec_import_deep "${1#*:}" "$2" ;;
     *) shellspec_error "Import failed, '$2' not found" ;;
   esac
-}
-
-shellspec_import_() {
-  if [ -e "$1/$2.sh" ]; then
-    # shellcheck disable=SC1090
-    . "$1/$2.sh"
-    return 0
-  fi
-  if [ -e "$1/$2/$2.sh" ]; then
-    # shellcheck disable=SC1090
-    . "$1/$2/$2.sh"
-    return 0
-  fi
-  return 1
 }
 
 if [ "$SHELLSPEC_SHELL_TYPE" = "zsh" ]; then


### PR DESCRIPTION
Shell that fails without workaround
- bash 4.1.2, 4.1.5
- bash 4.2.37, 4.2.46, 4.2.53
- bash 4.3.30, 4.3.42, bash 4.3.43
- posh 0.8.5. 0.12.3, 0.12.6, 0.13.1, 0.13.2
- mksh-39, 40
- pdksh 5.2.14

Shell that fails with workaround on dsl.sh.
- bash 4.1.2, 4.1.5
- bash 4.2.37, 4.2.46, 4.2.53
- bash 4.3.30, 4.3.42, bash 4.3.43
- ~~posh 0.8.5. 0.12.3, 0.12.6, 0.13.1, 0.13.2~~
- ~~mksh-39, 40~~
- ~~pdksh 5.2.14~~

Shell that fails with workaround on dsl.sh + evaluation.sh.
- ~~bash 4.1.2, 4.1.5~~
- ~~bash 4.2.37, 4.2.46, 4.2.53~~
- bash 4.3.30, 4.3.42, bash 4.3.43
- ~~posh 0.8.5. 0.12.3, 0.12.6, 0.13.1, 0.13.2~~
- ~~mksh-39, 40~~
- ~~pdksh 5.2.14~~

All fixed with workaround on dsl.sh + evaluation.sh + general.sh.
