### PR TITLE
Improve data helper

### DIFF
--- a/lib/core/dsl.sh
+++ b/lib/core/dsl.sh
@@ -4,6 +4,16 @@ SHELLSPEC_DESCRIPTION=''
 SHELLSPEC_PATH_ALIAS=:
 SHELLSPEC_INTERCEPTOR='|'
 
+shellspec_group_id() {
+  # shellcheck disable=SC2034
+  SHELLSPEC_GROUP_ID=$1 SHELLSPEC_BLOCK_NO=$2
+}
+
+shellspec_example_id() {
+  # shellcheck disable=SC2034
+  SHELLSPEC_EXAMPLE_ID=$1 SHELLSPEC_EXAMPLE_NO=$2 SHELLSPEC_BLOCK_NO=$3
+}
+
 shellspec_metadata() {
   if [ "${1:-}" ]; then
     shellspec_output METADATA
@@ -363,4 +373,17 @@ shellspec_is_temporary_skip() {
 
 shellspec_is_temporary_pending() {
   case ${SHELLSPEC_PENDING_REASON:-} in ("" | \# | \#\ *) ;; (*) false; esac
+}
+
+shellspec_cat() {
+  while IFS= read -r line || [ "$line" ]; do
+    shellspec_putsn "$line"
+  done
+}
+
+# shellcheck disable=SC2034
+shellspec_filter() {
+  if [ "${1:-}" ]; then SHELLSPEC_ENABLED=$1; fi
+  if [ "${2:-}" ]; then SHELLSPEC_FOCUSED=$2; fi
+  if [ "${3:-}" ]; then SHELLSPEC_FILTER=$3; fi
 }

--- a/lib/core/evaluation.sh
+++ b/lib/core/evaluation.sh
@@ -13,6 +13,15 @@ shellspec_syntax 'shellspec_evaluation_run'
 
 shellspec_proxy 'shellspec_evaluation' 'shellspec_syntax_dispatch evaluation'
 
+shellspec_invoke_data() {
+  if [ "${SHELLSPEC_DATA:-}" ]; then
+    case $# in
+      0) shellspec_data > "$SHELLSPEC_STDIN_FILE" ;;
+      *) shellspec_data "$@" > "$SHELLSPEC_STDIN_FILE" ;;
+    esac
+  fi
+}
+
 shellspec_evaluation_call() {
   shellspec_coverage_start
   set "$SHELLSPEC_ERREXIT"
@@ -20,7 +29,6 @@ shellspec_evaluation_call() {
   if [ ! "${SHELLSPEC_DATA:-}" ]; then
     shellspec_around_call "$@" < "$SHELLSPEC_STDIN_DEV"
   else
-    shellspec_data > "$SHELLSPEC_STDIN_FILE"
     shellspec_around_call "$@" < "$SHELLSPEC_STDIN_FILE"
   fi >"$SHELLSPEC_STDOUT_FILE" 2>"$SHELLSPEC_STDERR_FILE" &&:
   shellspec_evaluation_cleanup $?
@@ -63,7 +71,6 @@ shellspec_evaluation_run_data() {
     shellspec_evaluation_run_trap_exit_status "$@" < "$SHELLSPEC_STDIN_DEV" \
       >"$SHELLSPEC_STDOUT_FILE" 2>"$SHELLSPEC_STDERR_FILE"
   else
-    shellspec_data > "$SHELLSPEC_STDIN_FILE"
     shellspec_evaluation_run_trap_exit_status "$@" < "$SHELLSPEC_STDIN_FILE" \
       >"$SHELLSPEC_STDOUT_FILE" 2>"$SHELLSPEC_STDERR_FILE"
   fi

--- a/lib/core/evaluation.sh
+++ b/lib/core/evaluation.sh
@@ -48,7 +48,9 @@ shellspec_evaluation_run() {
 }
 
 shellspec_evaluation_run_subshell() {
-  ( set "$1"; shift; shellspec_evaluation_run_data "$@" )
+  ( set "$1"; shift
+    shellspec_evaluation_run_data "$@"
+  )
 }
 
 # Workaround for #40 in contrib/bugs.sh

--- a/lib/libexec/grammar.sh
+++ b/lib/libexec/grammar.sh
@@ -47,8 +47,8 @@ mapping() {
     fIt               ) f block_example       "$2" ;;
     End               )   block_end           "$2" ;;
     Todo              )   todo                "$2" ;;
-    When              )   statement when      "$2" ;;
-    The               )   statement the       "$2" ;;
+    When              )   evaluation when     "$2" ;;
+    The               )   expectation the     "$2" ;;
     Path              )   control path        "$2" ;;
     File              )   control path        "$2" ;;
     Dir               )   control path        "$2" ;;

--- a/lib/libexec/translator.sh
+++ b/lib/libexec/translator.sh
@@ -230,17 +230,24 @@ data() {
   case ${2:-} in
     '' | \#* | \|*)
       trans data_here_begin "$1" "${2:-}"
-      line=''
+      line='' error=
       while read_specfile line; do
         trim line "$line"
         case $line in
           \#\|*) trans data_here_line "$line" ;;
-          \#*) ;;
+          \# | \#\ * | \#$SHELLSPEC_TAB*) ;;
           End | End\ * ) break ;;
-          *) syntax_error "Data texts should begin with '#|'"; break ;;
+          *)
+            if [ ! "$error" ]; then
+              error=$(syntax_error "Data text should begin with '#|' or '# '")
+            fi
         esac
       done
-      trans data_here_end ;;
+      trans data_here_end
+      if [ "$error" ]; then
+        putsn "$error"
+      fi
+      ;;
     \'* | \"*) trans data_text "$2" ;;
     \<*) trans data_file "$2" ;;
     *) trans data_func "$2" ;;

--- a/lib/libexec/translator.sh
+++ b/lib/libexec/translator.sh
@@ -178,12 +178,20 @@ todo() {
   block_end ""
 }
 
-statement() {
+evaluation() {
   if [ -z "$inside_of_example" ]; then
-    syntax_error "When/The cannot be defined outside of Example"
+    syntax_error "When cannot be defined outside of Example"
     return 0
   fi
-  eval trans statement ${1+'"$@"'}
+  eval trans evaluation ${1+'"$@"'}
+}
+
+expectation() {
+  if [ -z "$inside_of_example" ]; then
+    syntax_error "The cannot be defined outside of Example"
+    return 0
+  fi
+  eval trans expectation ${1+'"$@"'}
 }
 
 control() {

--- a/libexec/shellspec-translate.sh
+++ b/libexec/shellspec-translate.sh
@@ -59,7 +59,16 @@ trans_block_end() {
   putsn "shellspec_block${block_no}) ${1# }"
 }
 
-trans_statement() {
+trans_evaluation() {
+  putsn "SHELLSPEC_LINENO=$lineno"
+  putsn "if [ \$# -eq 0 ]"
+  putsn "then shellspec_invoke_data"
+  putsn "else shellspec_invoke_data \"\$@\""
+  putsn "fi"
+  putsn "shellspec_statement $1 $2"
+}
+
+trans_expectation() {
   putsn "SHELLSPEC_LINENO=$lineno"
   putsn "shellspec_statement $1 $2"
 }

--- a/libexec/shellspec-translate.sh
+++ b/libexec/shellspec-translate.sh
@@ -17,15 +17,11 @@ trans() {
 trans_block_example_group() {
   putsn "("
   [ "$skipped" ] && trans_skip ""
-  putsn \
-    "SHELLSPEC_BLOCK_NO=$block_no" \
-    "SHELLSPEC_GROUP_ID=$block_id" \
-    "SHELLSPEC_LINENO_BEGIN=$lineno_begin"
+  putsn "shellspec_group_id $block_id $block_no"
+  putsn "SHELLSPEC_LINENO_BEGIN=$lineno_begin"
   putsn "shellspec_marker \"$specfile\" $lineno"
   putsn "shellspec_block${block_no}() { "
-  [ "$focused" ] && putsn "SHELLSPEC_FOCUSED=$focused"
-  [ "$filter" ] && putsn "SHELLSPEC_FILTER=$filter"
-  [ "$enabled" ] && putsn "SHELLSPEC_ENABLED=$enabled"
+  putsn "shellspec_filter '$enabled' '$focused' '$filter'"
   putsn "shellspec_example_group $1"
   putsn "}; shellspec_yield${block_no}() { :;"
 }
@@ -33,16 +29,11 @@ trans_block_example_group() {
 trans_block_example() {
   putsn "("
   [ "$skipped" ] && trans_skip ""
-  putsn \
-    "SHELLSPEC_BLOCK_NO=$block_no" \
-    "SHELLSPEC_EXAMPLE_ID=$block_id" \
-    "SHELLSPEC_LINENO_BEGIN=$lineno_begin" \
-    "SHELLSPEC_EXAMPLE_NO=$example_no"
+  putsn "shellspec_example_id $block_id $example_no $block_no"
+  putsn "SHELLSPEC_LINENO_BEGIN=$lineno_begin"
   putsn "shellspec_marker \"$specfile\" $lineno"
   putsn "shellspec_block${block_no}() { "
-  [ "$focused" ] && putsn "SHELLSPEC_FOCUSED=$focused"
-  [ "$filter" ] && putsn "SHELLSPEC_FILTER=$filter"
-  [ "$enabled" ] && putsn "SHELLSPEC_ENABLED=$enabled"
+  putsn "shellspec_filter '$enabled' '$focused' '$filter'"
   putsn "shellspec_example_block"
   putsn "}; shellspec_example${block_no}() { "
   putsn "if [ \$# -eq 0 ]"
@@ -55,7 +46,7 @@ trans_block_example() {
 trans_block_end() {
   putsn "shellspec_marker \"$specfile\" $lineno"
   putsn "}; SHELLSPEC_LINENO_END=$lineno_end"
-  [ "$enabled" ] && putsn "SHELLSPEC_ENABLED=$enabled"
+  putsn "shellspec_filter '$enabled'"
   putsn "shellspec_block${block_no}) ${1# }"
 }
 
@@ -94,8 +85,8 @@ trans_data_begin() {
 
 trans_data_here_begin() {
   case $1 in
-    expand) putsn "cat <<$delimiter $2" ;;
-    raw)    putsn "cat <<'$delimiter' $2" ;;
+    expand) putsn "shellspec_cat <<$delimiter $2" ;;
+    raw)    putsn "shellspec_cat <<'$delimiter' $2" ;;
   esac
 }
 
@@ -116,7 +107,7 @@ trans_data_func() {
 }
 
 trans_data_file() {
-  putsn "cat ${1#<}"
+  putsn "shellspec_cat $1"
 }
 
 trans_data_end() {
@@ -126,8 +117,8 @@ trans_data_end() {
 
 trans_text_begin() {
   case $1 in
-    expand) putsn "cat <<$delimiter $2" ;;
-    raw)    putsn "cat <<'$delimiter' $2" ;;
+    expand) putsn "shellspec_cat <<$delimiter $2" ;;
+    raw)    putsn "shellspec_cat <<'$delimiter' $2" ;;
   esac
 }
 

--- a/spec/core/dsl/parameters_spec.sh
+++ b/spec/core/dsl/parameters_spec.sh
@@ -90,4 +90,20 @@ Describe 'Parameters helper'
       The result of 'desc()' should eq "example $1 $2"
     End
   End
+
+  Describe 'Using with data helper'
+    Parameters
+      a       A      Abc
+      b       B      aBc
+    End
+
+    Data:expand
+    #|abc
+    End
+
+    It "example $1 $2"
+      When call tr "$1" "$2"
+      The output should eq "$3"
+    End
+  End
 End

--- a/spec/core/dsl_spec.sh
+++ b/spec/core/dsl_spec.sh
@@ -7,6 +7,44 @@
 Include "$SHELLSPEC_LIB/core/dsl.sh"
 
 Describe "core/dsl.sh"
+  Describe "shellspec_group_id()"
+    setup() {
+      SHELLSPEC_GROUP_ID="" SHELLSPEC_BLOCK_NO=""
+    }
+    check() {
+      echo "$SHELLSPEC_GROUP_ID"
+      echo "$SHELLSPEC_BLOCK_NO"
+    }
+    BeforeRun setup
+    AfterRun check
+
+    It 'sets group id'
+      When run shellspec_group_id 10 20
+      The line 1 of stdout should eq 10
+      The line 2 of stdout should eq 20
+    End
+  End
+
+  Describe "shellspec_example_id()"
+    setup() {
+      SHELLSPEC_EXAMPLE_ID="" SHELLSPEC_EXAMPLE_NO="" SHELLSPEC_BLOCK_NO=""
+    }
+    check() {
+      echo "$SHELLSPEC_EXAMPLE_ID"
+      echo "$SHELLSPEC_EXAMPLE_NO"
+      echo "$SHELLSPEC_BLOCK_NO"
+    }
+    BeforeRun setup
+    AfterRun check
+
+    It 'sets group id'
+      When run shellspec_example_id 10 20 30
+      The line 1 of stdout should eq 10
+      The line 2 of stdout should eq 20
+      The line 3 of stdout should eq 30
+    End
+  End
+
   Describe "shellspec_metadata()"
     mock() { shellspec_output() { echo "$1"; }; }
     BeforeRun mock
@@ -827,6 +865,19 @@ Describe "core/dsl.sh"
     End
   End
 
+  Describe "shellspec_cat"
+    Data
+    #|test1
+    #|test2
+    End
+
+    It "outputs data"
+      When call shellspec_cat
+      The line 1 of stdout should eq "test1"
+      The line 2 of stdout should eq "test2"
+    End
+  End
+
   Describe 'BeforeCall / AfterCall'
     before() { echo before; }
     after() { echo after; }
@@ -982,6 +1033,40 @@ Describe "core/dsl.sh"
         The line 2 of stdout should eq 'foo'
         The stderr should be present
       End
+    End
+  End
+
+  Describe "shellspec_filter()"
+    setup() {
+      SHELLSPEC_ENABLED="" SHELLSPEC_FILTER="" SHELLSPEC_FOCUSED=""
+    }
+    check() {
+      echo "$SHELLSPEC_ENABLED"
+      echo "$SHELLSPEC_FOCUSED"
+      echo "$SHELLSPEC_FILTER"
+    }
+    BeforeRun setup
+    AfterRun check
+
+    It 'sets enabled flag'
+      When run shellspec_filter 1
+      The line 1 of stdout should be present
+      The line 2 of stdout should be blank
+      The line 3 of stdout should be blank
+    End
+
+    It 'sets focused flag'
+      When run shellspec_filter "" 1
+      The line 1 of stdout should be blank
+      The line 2 of stdout should be present
+      The line 3 of stdout should be blank
+    End
+
+    It 'sets filter flag'
+      When run shellspec_filter "" "" 1
+      The line 1 of stdout should be blank
+      The line 2 of stdout should be blank
+      The line 3 of stdout should be present
     End
   End
 End

--- a/spec/core/evaluation_spec.sh
+++ b/spec/core/evaluation_spec.sh
@@ -7,6 +7,29 @@ Describe "core/evaluation.sh"
   Include "$SHELLSPEC_LIB/core/evaluation.sh"
   Before 'VAR=123'
 
+  Describe 'shellspec_invoke_data()'
+    shellspec_data() {
+      echo "${1:-test1}"
+      echo "${2:-test2}"
+    }
+
+    BeforeRun SHELLSPEC_DATA=1
+
+    It 'generates data'
+      File in-file="$SHELLSPEC_STDIN_FILE"
+      When run shellspec_invoke_data
+      The line 1 of contents of file in-file should equal 'test1'
+      The line 2 of contents of file in-file should equal 'test2'
+    End
+
+    It 'generates data with parameters'
+      File in-file="$SHELLSPEC_STDIN_FILE"
+      When run shellspec_invoke_data testA testB
+      The line 1 of contents of file in-file should equal 'testA'
+      The line 2 of contents of file in-file should equal 'testB'
+    End
+  End
+
   Describe 'call evaluation'
     It 'outputs to stdout and stderr'
       evaluation() { echo ok; echo err >&2; return 0; }

--- a/spec/libexec/translator_spec.sh
+++ b/spec/libexec/translator_spec.sh
@@ -176,4 +176,82 @@ Describe "libexec/translator.sh"
       The line 2 of stdout should eq 12346
     End
   End
+
+  Describe "data()"
+    BeforeRun lineno=12345
+    trans() { echo "$@"; }
+
+    _data() {
+      {
+        echo "# comment"
+        echo "#|aaa"
+      } | data "$@"
+    }
+
+    It "reads text data"
+      When run _data "===="
+      The line 1 of stdout should eq "data_begin ===="
+      The line 2 of stdout should eq "data_here_begin ==== "
+      The line 3 of stdout should eq "data_here_line #|aaa"
+      The line 4 of stdout should eq "data_here_end"
+      The line 5 of stdout should eq "data_end ===="
+    End
+
+    It "reads text data (with comment)"
+      When run _data "====" "# comment"
+      The line 1 of stdout should eq "data_begin ==== # comment"
+      The line 2 of stdout should eq "data_here_begin ==== # comment"
+      The line 3 of stdout should eq "data_here_line #|aaa"
+      The line 4 of stdout should eq "data_here_end"
+      The line 5 of stdout should eq "data_end ==== # comment"
+    End
+
+    It "reads text data (with filter)"
+      When run _data "====" "| tr"
+      The line 1 of stdout should eq "data_begin ==== | tr"
+      The line 2 of stdout should eq "data_here_begin ==== | tr"
+      The line 3 of stdout should eq "data_here_line #|aaa"
+      The line 4 of stdout should eq "data_here_end"
+      The line 5 of stdout should eq "data_end ==== | tr"
+    End
+
+    It "outputs error with invalid line"
+      _data() { echo "error" | data "$@"; }
+      syntax_error() { echo "$@"; }
+      When run _data "===="
+      The line 1 of stdout should eq "data_begin ===="
+      The line 2 of stdout should eq "data_here_begin ==== "
+      The line 3 of stdout should eq "data_here_end"
+      The line 4 of stdout should eq "Data text should begin with '#|' or '# '"
+      The line 5 of stdout should eq "data_end ===="
+    End
+
+    It "reads text data from quoted argument"
+      When run data "====" "'string'"
+      The line 1 of stdout should eq "data_begin ==== 'string'"
+      The line 2 of stdout should eq "data_text 'string'"
+      The line 3 of stdout should eq "data_end ==== 'string'"
+    End
+
+    It "reads text data from double quoted argument"
+      When run data "====" "\"string\""
+      The line 1 of stdout should eq "data_begin ==== \"string\""
+      The line 2 of stdout should eq "data_text \"string\""
+      The line 3 of stdout should eq "data_end ==== \"string\""
+    End
+
+    It "reads text data from function"
+      When run data "====" "func"
+      The line 1 of stdout should eq "data_begin ==== func"
+      The line 2 of stdout should eq "data_func func"
+      The line 3 of stdout should eq "data_end ==== func"
+    End
+
+    It "reads text data from file"
+      When run data "====" "< file"
+      The line 1 of stdout should eq "data_begin ==== < file"
+      The line 2 of stdout should eq "data_file < file"
+      The line 3 of stdout should eq "data_end ==== < file"
+    End
+  End
 End


### PR DESCRIPTION
Improvement

- Support  `Parameters` with `Data` helper.

Change

-  To avoid typo, Comments in the `Data` helper only accept those starts with  `#<space>` not `#`.

Close #57