### PR TITLE
/dev/tty may exist, but not be writable.

### DIFF
--- a/libexec/shellspec-translate.sh
+++ b/libexec/shellspec-translate.sh
@@ -192,7 +192,7 @@ putsn ". \"\$SHELLSPEC_LIB/bootstrap.sh\""
 putsn "shellspec_coverage_setup \"\$SHELLSPEC_SHELL_TYPE\""
 putsn "shellspec_metadata $metadata"
 
-log() { if [ -e /dev/tty ]; then puts "$@" >/dev/tty; fi; }
+log() { if [ -t 1 ]; then puts "$@" >/dev/tty; fi; }
 
 specfile_count=0
 count_specfile() {

--- a/libexec/shellspec-translate.sh
+++ b/libexec/shellspec-translate.sh
@@ -192,7 +192,7 @@ putsn ". \"\$SHELLSPEC_LIB/bootstrap.sh\""
 putsn "shellspec_coverage_setup \"\$SHELLSPEC_SHELL_TYPE\""
 putsn "shellspec_metadata $metadata"
 
-log() { if [ -t 1 ]; then puts "$@" >/dev/tty; fi; }
+log() { if (: > /dev/tty) 2>/dev/null; then puts "$@" >/dev/tty; fi; }
 
 specfile_count=0
 count_specfile() {


### PR DESCRIPTION
This checks if the file descriptor 1 is available, which is standard output.

Fixes #66 