### PR TITLE
Add number shorthand

### DIFF
--- a/lib/core/utils.sh
+++ b/lib/core/utils.sh
@@ -2,10 +2,15 @@
 
 shellspec_is() {
   case $1 in
-    number) case ${2:-} in ( '' | *[!0-9]* ) return 1; esac ;;
+    number) shellspec_is_number "${2:-}" || return 1 ;;
     funcname) shellspec_is_function "${2:-}" || return 1 ;;
     *) shellspec_error "shellspec_is: invalid type name '$1'"
   esac
+  return 0
+}
+
+shellspec_is_number() {
+  case ${1:-} in ( '' | *[!0-9]* ) return 1; esac
   return 0
 }
 

--- a/spec/core/utils_spec.sh
+++ b/spec/core/utils_spec.sh
@@ -65,6 +65,50 @@ Describe "core/utils.sh"
     End
   End
 
+  Describe 'shellspec_is_number()'
+    Parameters
+      123       success
+      "-123"    failure
+      123.0     failure
+      @         failure
+    End
+
+    It 'checks if number'
+      When call shellspec_is_number "$1"
+      The status should be "$2"
+    End
+  End
+
+  Describe 'shellspec_is_function()'
+    Parameters
+      foo       success
+      foo123    success
+      foo_123   success
+      _foo_123  success
+      @         failure
+    End
+
+    It 'checks if function'
+      When call shellspec_is_function "$1"
+      The status should be "$2"
+    End
+  End
+
+  Describe 'shellspec_is_identifier()'
+    Parameters
+      foo       success
+      foo123    success
+      foo_123   success
+      _foo_123  success
+      @         failure
+    End
+
+    It 'checks if identifier'
+      When call shellspec_is_identifier "$1"
+      The status should be "$2"
+    End
+  End
+
   Describe 'shellspec_append_set()'
     Before op=''
 


### PR DESCRIPTION
Example

```sh
The line#2 should equal "2 BAR"
The line#2 of stdout should equal "2 BAR"
The word#2 of line#2 should equal "BAR"
The word#4 should equal "BAR"
```

Close #54