### PR TITLE
Replace -C, --directory option to --execdir option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ uninstall:
 package:
 	contrib/make_package_json.sh > package.json
 
-getoptions:
+optparser:
 	$(GETOPTIONS) $(GETOPTIONS_IN) $(GETOPTIONS_PARAMS) > $(GETOPTIONS_OUT)
 
 demo:

--- a/lib/core/dsl.sh
+++ b/lib/core/dsl.sh
@@ -69,7 +69,7 @@ shellspec_begin() {
   shellspec_output BEGIN
 }
 
-shellspec_location() {
+shellspec_execdir() {
   case $1 in
     @project | @project/*) set -- "${1#@project}" ;;
     @basedir | @basedir/*)

--- a/lib/libexec/optparser/parser_definition.sh
+++ b/lib/libexec/optparser/parser_definition.sh
@@ -1,5 +1,11 @@
 # shellcheck shell=sh
 
+# Use getoptions to generate the option parser
+# https://github.com/ko1nksm/getoptions
+#
+# To generate the code of the option parser,
+# modify the following code and run `make optparser`.
+
 # shellcheck disable=SC1083,SC2016
 parser_definition() {
   : "${2?No variable prefix specified}"
@@ -32,12 +38,12 @@ parser_definition() {
   multi REQUIRES ':' --require var:MODULE -- \
     'Require a MODULE (shell script file)'
 
-  param DIRECTORY -C --directory init:='@project' validate:check_directory var:"@LOCATION[/DIR]" \
+  param EXECDIR --execdir init:='@project' validate:check_directory var:"@LOCATION[/DIR]" \
     pattern:'@project | @project/* | @basedir | @basedir/* | @specfile | @specfile/*' -- \
-    'Change to the directory before running each specfile | [default: @project]' \
-    '  [@project]       Project root directory [default]' \
-    '  [@basedir]       Where the file .shellspec-basedir is located' \
-    '  [@specfile]      Where the specfile is located' \
+    'Specify the execution directory of each specfile | [default: @project]' \
+    '  [@project]   Where the ".shellspec" file is located (project root) [default]' \
+    '  [@basedir]   Where the ".shellspec" or ".shellspec-basedir" file is located' \
+    '  [@specfile]  Where the specfile is located' \
     '  In addition, it can be specified a directory relative to the location'
 
   param :set_env -e --env validate:check_env_name var:'NAME[=VALUE]' -- \

--- a/lib/libexec/optparser/parser_definition_generated.sh
+++ b/lib/libexec/optparser/parser_definition_generated.sh
@@ -5,7 +5,7 @@ export SHELLSPEC_SHELL=''
 export SHELLSPEC_SANDBOX=''
 export SHELLSPEC_SANDBOX_PATH=''
 export SHELLSPEC_REQUIRES=''
-export SHELLSPEC_DIRECTORY='@project'
+export SHELLSPEC_EXECDIR='@project'
 export SHELLSPEC_ENV_FROM=''
 export SHELLSPEC_WARNING_AS_FAILURE='1'
 export SHELLSPEC_FAIL_FAST_COUNT=''
@@ -74,9 +74,9 @@ optparser_parse() {
         "$1") OPTARG=; break ;;
         $1*) OPTARG="$OPTARG --require"
       esac
-      case '--directory' in
+      case '--execdir' in
         "$1") OPTARG=; break ;;
-        $1*) OPTARG="$OPTARG --directory"
+        $1*) OPTARG="$OPTARG --execdir"
       esac
       case '--env' in
         "$1") OPTARG=; break ;;
@@ -339,7 +339,7 @@ optparser_parse() {
         eval 'set -- "${OPTARG%%\=*}" "${OPTARG#*\=}"' ${1+'"$@"'}
         ;;
       --no-*) unset OPTARG ;;
-      -[sCejfoPETD]?*) OPTARG=$1; shift
+      -[sejfoPETD]?*) OPTARG=$1; shift
         eval 'set -- "${OPTARG%"${OPTARG#??}"}" "${OPTARG#??}"' ${1+'"$@"'}
         ;;
       -[!-]?*) OPTARG=$1; shift
@@ -376,14 +376,14 @@ optparser_parse() {
         OPTARG=$2
         multiple SHELLSPEC_REQUIRES ':' SHELLSPEC
         shift ;;
-      '-C'|'--directory')
+      '--execdir')
         [ $# -le 1 ] && set "required" "$1" && break
         OPTARG=$2
         check_directory || { set -- check_directory:$? "$1" check_directory; break; }
         case $OPTARG in @project | @project/* | @basedir | @basedir/* | @specfile | @specfile/*) ;;
           *) set "pattern:@project | @project/* | @basedir | @basedir/* | @specfile | @specfile/*" "$1"; break
         esac
-        export SHELLSPEC_DIRECTORY="$OPTARG"
+        export SHELLSPEC_EXECDIR="$OPTARG"
         shift ;;
       '-e'|'--env')
         [ $# -le 1 ] && set "required" "$1" && break
@@ -705,10 +705,10 @@ Usage: shellspec [options...] [files or directories...]
                                       This is not a security feature and does not provide complete isolation
         --sandbox-path PATH         Make PATH the sandbox path instead of empty (default: empty)
         --require MODULE            Require a MODULE (shell script file)
-    -C, --directory @LOCATION[/DIR] Change to the directory before running each specfile | [default: @project]
-                                      [@project]       Project root directory [default]
-                                      [@basedir]       Where the file .shellspec-basedir is located
-                                      [@specfile]      Where the specfile is located
+        --execdir @LOCATION[/DIR]   Specify the execution directory of each specfile | [default: @project]
+                                      [@project]   Where the ".shellspec" file is located (project root) [default]
+                                      [@basedir]   Where the ".shellspec" or ".shellspec-basedir" file is located
+                                      [@specfile]  Where the specfile is located
                                       In addition, it can be specified a directory relative to the location
     -e, --env NAME[=VALUE]          Set environment variable
         --env-from ENV-SCRIPT       Set environment variable from shell script file

--- a/libexec/shellspec-translate.sh
+++ b/libexec/shellspec-translate.sh
@@ -249,15 +249,15 @@ specfile() {
   [ -e "$2" ] || return 0
   progress "${CR}Translate[$spec_no/$specfile_count]: $2${ESC}[K"
   (
-    specfile=$2 ranges=${3:-} run_all='' location=$SHELLSPEC_DIRECTORY
+    specfile=$2 ranges=${3:-} run_all='' execdir=$SHELLSPEC_EXECDIR
     escape_quote specfile
-    escape_quote location
+    escape_quote execdir
     [ "$ranges" ] && enabled='' || enabled=1
     [ "$enabled" ] && [ "$filter" ] && run_all=1
 
     putsn "shellspec_marker '$specfile' ---"
     putsn "(shellspec_begin '$specfile' '$spec_no'"
-    putsn "shellspec_location '$location'"
+    putsn "shellspec_execdir '$execdir'"
     putsn "shellspec_perform '$enabled' '$filter'"
     initialize
     putsn "shellspec_marker '$specfile' BOF"

--- a/spec/core/dsl_spec.sh
+++ b/spec/core/dsl_spec.sh
@@ -109,7 +109,7 @@ Describe "core/dsl.sh"
     End
   End
 
-  Describe "shellspec_location()"
+  Describe "shellspec_execdir()"
     Before SHELLSPEC_SPECFILE="spec/fixture/spec_structure/basedir/dir1/dir2/test_spec.sh"
     cd() { echo "$1"; }
 
@@ -129,8 +129,8 @@ Describe "core/dsl.sh"
       other         "$SHELLSPEC_PROJECT_ROOT" # May change the specifications in the future
     End
 
-    It 'changes the directory'
-      When run shellspec_location "$1"
+    It 'changes the execution directory'
+      When run shellspec_execdir "$1"
       The output should eq "$2"
     End
   End


### PR DESCRIPTION
Rename the option because their usage and meaning are different from those of tar or git's `-C` option.

NOTE: This option exists only in the master branch and has not yet been released.