### PR TITLE
Improving documentation for 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BeforeEach` / `AfterEach` as synonym for `Before` / `After`.
 - Added `FORCE_COLOR` environment variable.
 - Added `--tmpdir` option.
+- Added `--execdir` option to specify the directory for specfile execution.
+- Added `-c` (`--chdir`) and `-C` (`--directory`) options to change directory at startup.
+- Added path syntax (`*/` and `**/`) and `-L` (`--dereference`) option to match recursive directories.
+- Added `--helperdir` to specify the location of `spec_helper` etc.
+- Added the environment variable `SHELLSPEC_HELPERDIR` to indicate the location of `spec_helper` etc.
+- Added `--reportdir` and `--covdir` options.
+- Added `-O` (`--option`) option.
+- Added `-I` (`--load-path`) option.
+- Added `<module>_precheck` callback and some helper functions to `spec_helper` for pre-checking.
+- Added `<module>_loaded` callback to be called after `spec_helper` loading.
 
 ### Changed
 
+- Replaced with a new option parser [getoptions](https://github.com/ko1nksm/getoptions) which supports the standard option syntax.
 - Replaced `--keep-tempdir` with `--keep-tmpdir`.
 - Specifying a file in the shellspec's argument is now ignored if it does not match `--pattern`.
+- Filled in system-out and system-err in junit xml.
+- Allowed run the tests from any subdirectory.
+- The `-D` option has been deprecated (Replace with the `--default-path` option).
+- The environment variable `SHELLSPEC_SPECDIR` has been deprecated since there is not always a single directory for specfiles.
+- Rename `.shellspec-profiler.log` to `profiler.log` for profiler log.
+- Accept `banner.md` as a banner file
+- `Include` and `import` (`shellspec_import`) can now pass arguments.
+- The delimiter of the environment variable `SHELLSPEC_REQUIRES` has been changed from `:` to space.
+- Improved documentation. (#117, #119 ldicarlo)
+- Improved documentation. (#120, #139 Antoni Marcinek)
+- Improved documentation. (#159 Leon Stafford)
 
 ### Removed
 
@@ -25,15 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - bash 4.1 - 4.3: Fixed a bug that `run script` could not get the exit status.
-- zsh < 4.2.0: Fixed a bug when extendedglob is enabled
-- Fixed possibility of I/O error in satisfy matcher (GitHub Actions only?)
-- Fixed a bug in which zsh on macOS occasionally exits with exit code 147 (SIGCONT)
+- zsh < 4.2.0: Fixed a bug when extendedglob is enabled.
+- Fixed possibility of I/O error in satisfy matcher (GitHub Actions only?).
+- Fixed a bug in which zsh on macOS occasionally exits with exit code 147 (SIGCONT).
+- Fixed several bugs related to the Windows path for busybox-w32.
 
 ## [0.27.2] - 2020-10-28
 
 ### Fixed
 
-- Fixed a bug that didn't cause an error if there are fixed examples
+- Fixed a bug that didn't cause an error if there are fixed examples.
 
 ## [0.27.1] - 2020-09-30
 

--- a/docs/directory_structure.md
+++ b/docs/directory_structure.md
@@ -1,58 +1,66 @@
 # Project directory structure
 
-- [`.shellspec` / `.shellspec-local` - configure default options](#shellspec--shellspec-local---configure-default-options)
-- [`.shellspec-quick.log` - log file for quick execution](#shellspec-quicklog---log-file-for-quick-execution)
-- [`report/` - output directory of report file](#report---output-directory-of-report-file)
-- [`coverage/` - output directory of coverage reports](#coverage---output-directory-of-coverage-reports)
-- [`spec/` - default specfiles directory](#spec---default-specfiles-directory)
-- [`spec/banner` - banner file displayed at test execution](#specbanner---banner-file-displayed-at-test-execution)
-- [`spec/spec_helper.sh` - default helper file for specfile](#specspec_helpersh---default-helper-file-for-specfile)
-- [`spec/support/` - directory for support files](#specsupport---directory-for-support-files)
-- [`spec/support/bin` - directory for support commands](#specsupportbin---directory-for-support-commands)
+## Example directory structure and options
 
-## `.shellspec` / `.shellspec-local` - configure default options
+Separate a separate directory for each utility and test it with `test_spec.sh`.
+The execution directory for testing is where the specfile is located.
 
-To change the default options for the `shellspec` command, create options file(s).
-Files are read in the order shown below, options defined last take precedence.
+```text
+<PROJECT-ROOT>
+├─ .shellspec
+│
+├─ script1/
+│   ├─ script1.sh
+│   └─ test_spec.sh
+│
+├─ script2/
+│   ├─ script2.sh
+│   └─ test_spec.sh
+│
+├─ spec/
+│   ├─ spec_helper.sh
+│   │        :
+```
 
-1. `$XDG_CONFIG_HOME/shellspec/options`
-2. `$HOME/.shellspec`
-3. `./.shellspec`
-4. `./.shellspec-local` (Do not store in VCS such as git)
+```test
+# .shellspec
+--default-path "**/test_spec.sh"
+--execdir @specfile
+````
 
-Specify your default options with `$XDG_CONFIG_HOME/shellspec/options` or `$HOME/.shellspec`.
-Specify default project options with `.shellspec` and overwrite to your favorites with `.shellspec-local`.
+Separate a separate directory for each utility and test it with `spec/*_spec.sh`.
+The test execution directory is where the script is located.
 
-## `.shellspec-quick.log` - log file for quick execution
+```text
+<PROJECT-ROOT>
+├─ .shellspec
+│
+├─ script1/
+│   ├─ .shellspec-basedir
+│   ├─ bin/
+│   │   ├─ script1.sh
+│   │   │    :
+│   └─ spec/
+│        ├─ script1_spec.sh
+│        │    :
+│
+├─ script2/
+│   ├─ .shellspec-basedir
+│   ├─ bin/
+│   │   ├─ script2.sh
+│   │   │    :
+│   └─ spec/
+│        ├─ script2_spec.sh
+│        │    :
+│
+├─ spec/
+│   ├─ spec_helper.sh
+│   ├─ support/
+│   │        :
+```
 
-Log file used for Quick execution.
-
-## `report/` - output directory of report file
-
-Directory for report output using the `--output` option.
-
-## `coverage/` - output directory of coverage reports
-
-Directory where kcov outputs coverage reports.
-
-## `spec/` - default specfiles directory
-
-Directory where you create specfiles.
-
-## `spec/banner` - banner file displayed at test execution
-
-If `spec/banner` file exists, the banner is shown when the `shellspec` command
-is executed. Disable that behavior with the `--no-banner` option.
-
-## `spec/spec_helper.sh` - default helper file for specfile
-
-The `spec_helper.sh` is loaded to specfile by the `--require spec_helper` option.
-This file is used to define global functions, initial setting for examples, custom matchers, etc.
-
-## `spec/support/` - directory for support files
-
-This directory is used to store files for custom matchers, tasks, etc.
-
-## `spec/support/bin` - directory for support commands
-
-This directory is used to store [support commands](#support-commands).
+```test
+# .shellspec
+--default-path "**/spec"
+--execdir @basedir/bin`
+````

--- a/docs/references.md
+++ b/docs/references.md
@@ -862,19 +862,23 @@ There are many undocumented variables. You can use them at your own risk.
 
 These variables can be overridden by the `--env-from` option, except for some
 variables. This is an assumed usage, but has not been fully tested.
+It is recommended to use it as read-only.
 
-| Name                 | Description                              | Value                                                               |
-| :------------------- | :--------------------------------------- | ------------------------------------------------------------------- |
-| SHELLSPEC_ROOT       | ShellSpec root directory                 |                                                                     |
-| SHELLSPEC_LIB        | ShellSpec lib directory                  | `${SHELLSPEC_ROOT}/lib`                                             |
-| SHELLSPEC_LIBEXEC    | ShellSpec libexec directory              | `${SHELLSPEC_ROOT}/libexec`                                         |
-| SHELLSPEC_TMPDIR     | Temporary directory                      | `${TMPDIR}` or `/tmp` if not specified.                             |
-| SHELLSPEC_TMPBASE    | Temporary directory used by ShellSpec    | `${SHELLSPEC_TMPDIR}/shellspec.${SHELLSPEC_UNIXTIME}.$$`.           |
-| SHELLSPEC_WORKDIR    | Temporary directory for each spec number | `${SHELLSPEC_TMPBASE}/${SHELLSPEC_SPEC_NO}`.                        |
-| SHELLSPEC_SPECDIR    | Specfiles directory                      | `${PWD}/spec`                                                       |
-| SHELLSPEC_LOAD_PATH  | Load path of library                     | `${SHELLSPEC_SPECDIR}:${SHELLSPEC_LIB}:${SHELLSPEC_LIB}/formatters` |
-| SHELLSPEC_UNIXTIME   | Unix Time when ShellSpec starts          |                                                                     |
-| SHELLSPEC_SPEC_NO    | Current specfile number                  |                                                                     |
-| SHELLSPEC_GROUP_ID   | Current group ID                         | e.g. `1-2`                                                          |
-| SHELLSPEC_EXAMPLE_ID | Current example ID (including group ID)  | e.g. `1-2-3`                                                        |
-| SHELLSPEC_EXAMPLE_NO | Current serial number of example         |                                                                     |
+| Name                   | Description                              | Value                                                               |
+| :--------------------- | :--------------------------------------- | ------------------------------------------------------------------- |
+| SHELLSPEC_ROOT         | ShellSpec root directory                 |                                                                     |
+| SHELLSPEC_LIB          | ShellSpec lib directory                  | `${SHELLSPEC_ROOT}/lib`                                             |
+| SHELLSPEC_LIBEXEC      | ShellSpec libexec directory              | `${SHELLSPEC_ROOT}/libexec`                                         |
+| SHELLSPEC_TMPDIR       | Temporary directory                      | `${TMPDIR}` or `/tmp` if not specified.                             |
+| SHELLSPEC_TMPBASE      | Temporary directory used by ShellSpec    | `${SHELLSPEC_TMPDIR}/shellspec.${SHELLSPEC_UNIXTIME}.$$`.           |
+| SHELLSPEC_WORKDIR      | Temporary directory for each spec number | `${SHELLSPEC_TMPBASE}/${SHELLSPEC_SPEC_NO}`.                        |
+| SHELLSPEC_PROJECT_ROOT | Where `.shellspec` is located            |                                                                     |
+| ~~SHELLSPEC_SPECDIR~~  | Specfiles directory                      | `${SHELLSPEC_PROJECT_ROOT}/spec` [depricated]                       |
+| SHELLSPEC_HELPERDIR    | spec_helper directory                    | `${SHELLSPEC_PROJECT_ROOT}/spec` (default)                          |
+| SHELLSPEC_LOAD_PATH    | Load path of library                     | `${SHELLSPEC_SPECDIR}:${SHELLSPEC_LIB}:${SHELLSPEC_LIB}/formatters` |
+| SHELLSPEC_UNIXTIME     | Unix Time when ShellSpec starts          |                                                                     |
+| SHELLSPEC_SPECFILE     | Current running specfile path            |                                                                     |
+| SHELLSPEC_SPEC_NO      | Current specfile number                  |                                                                     |
+| SHELLSPEC_GROUP_ID     | Current group ID                         | e.g. `1-2`                                                          |
+| SHELLSPEC_EXAMPLE_ID   | Current example ID (including group ID)  | e.g. `1-2-3`                                                        |
+| SHELLSPEC_EXAMPLE_NO   | Current serial number of example         |                                                                     |

--- a/helper/ksh_workaround.sh
+++ b/helper/ksh_workaround.sh
@@ -2,6 +2,8 @@
 
 ksh_workaround_loaded() {
   # for ksh93 and ksh2020
+  # These shells do not allow functions defined outside of the subshell
+  # to be redefined within the subshell. a hack using aliases avoids this.
   shellspec_redefinable shellspec_puts
   shellspec_redefinable shellspec_putsn
   shellspec_redefinable shellspec_output
@@ -38,6 +40,8 @@ ksh_workaround_loaded() {
   shellspec_redefinable shellspec_source
 
   # for ksh88 and busybox-1.1.3
+  # These shells do not allow built-in commands cannot be redefined
+  # by shell functions. a hack using aliases avoids this.
   shellspec_unbuiltin "ps"
   shellspec_unbuiltin "last"
   shellspec_unbuiltin "sleep"


### PR DESCRIPTION
Add documentation on the following changes:

- #135 Allow run the tests from any subdirectory
- #146 Replace -C, --directory option to --execdir option (#137 Add -C, --directory option)