### PR TITLE
Fix a bug that test command cannot redefine when using "when run source"

### DIFF
--- a/helper/fixture/test_when_run_source
+++ b/helper/fixture/test_when_run_source
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+test dummy

--- a/lib/core/evaluation.sh
+++ b/lib/core/evaluation.sh
@@ -219,13 +219,15 @@ shellspec_evaluation_run_command() {
 }
 
 shellspec_evaluation_run_source() {
-  test() {
-    case $# in
-      0) test() { case $# in (0) false ;; (*) [ "$@" ]; esac; } ;;
-      *) [ "$@" ] ;;
-    esac
-  }
-  __() { shellspec_interceptor "$@"; }
+  if [ "${SHELLSPEC_INTERCEPTOR#\|}" ]; then
+    test() {
+      case $# in
+        0) test() { case $# in (0) false ;; (*) [ "$@" ]; esac; } ;;
+        *) [ "$@" ] ;;
+      esac
+    }
+    __() { shellspec_interceptor "$@"; }
+  fi
   shellspec_coverage_start
   # shellcheck disable=SC2031
   if [ "$SHELLSPEC_XTRACE" ]; then

--- a/spec/core/evaluation_spec.sh
+++ b/spec/core/evaluation_spec.sh
@@ -501,6 +501,12 @@ Describe "core/evaluation.sh"
           The line 3 should eq "xtrace off"
         End
       End
+
+      It "can be redefined the test command"
+        test() { echo "test command redefined"; }
+        When run shellspec_evaluation_run_source "$FIXTURE/test_when_run_source"
+        The output should eq "test command redefined"
+      End
     End
   End
 


### PR DESCRIPTION
Close #163