### PR TITLE
Scaffold files, implement array subject, implement array be size matcher

### DIFF
--- a/examples-array/.shellspec
+++ b/examples-array/.shellspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--require array

--- a/examples-array/spec/spec_helper.sh
+++ b/examples-array/spec/spec_helper.sh
@@ -1,0 +1,3 @@
+#shellcheck shell=sh
+
+# set -eu

--- a/examples-array/spec/test_spec.sh
+++ b/examples-array/spec/test_spec.sh
@@ -1,0 +1,15 @@
+#shellcheck shell=bash
+
+Describe 'array module'
+  Describe 'create_array()'
+    create_array() {
+      #shellcheck disable=SC2034
+      TEST_ARRAY=("aa" "bb" "c c c")
+    }
+
+    It 'should create an array with 3 items'
+      When call create_array
+      The array 'TEST_ARRAY' should be size 3
+    End
+  End
+End

--- a/lib/array/array.sh
+++ b/lib/array/array.sh
@@ -1,0 +1,8 @@
+#shellcheck shell=sh
+
+array_configure() {
+    shellspec_import "array/utils"
+    shellspec_import "array/matchers"
+    shellspec_import "array/modifiers"
+    shellspec_import "array/subjects"
+}

--- a/lib/array/matchers.sh
+++ b/lib/array/matchers.sh
@@ -1,0 +1,3 @@
+#shellcheck shell=sh
+
+shellspec_import 'array/matchers/be'

--- a/lib/array/matchers/be.sh
+++ b/lib/array/matchers/be.sh
@@ -1,0 +1,5 @@
+#shellcheck shell=sh
+
+shellspec_syntax_chain 'shellspec_matcher_be'
+
+shellspec_import 'array/matchers/be/size'

--- a/lib/array/matchers/be/size.sh
+++ b/lib/array/matchers/be/size.sh
@@ -1,0 +1,32 @@
+#shellcheck shell=sh
+
+shellspec_syntax 'shellspec_matcher_be_size'
+
+shellspec_matcher_be_size() {
+  shellspec_matcher__match() {
+    # expected item count
+    SHELLSPEC_EXPECT="$1"
+
+    # fail if SHELLSPEC_SUBJECT undefined
+    [ "${SHELLSPEC_SUBJECT+x}" ] || return 1
+
+    # fail if different size
+    [ "${#SHELLSPEC_SUBJECT[@]}" -eq "$SHELLSPEC_EXPECT" ] || return 1
+
+    # success
+    return 0
+  }
+
+  #shellcheck disable=SC2016
+  shellspec_syntax_failure_message + \
+      'expected ${#SHELLSPEC_SUBJECT[@]} to be $2' \
+      'array: ${SHELLSPEC_SUBJECT[@]}'
+
+  #shellcheck disable=SC2016
+  shellspec_syntax_failure_message - \
+      'expected ${#SHELLSPEC_SUBJECT[@]} to not be $2' \
+      'array: ${SHELLSPEC_SUBJECT[@]}'
+
+  shellspec_syntax_param count [ $# -eq 1 ] || return 0
+  shellspec_matcher_do_match "$@"
+}

--- a/lib/array/modifiers.sh
+++ b/lib/array/modifiers.sh
@@ -1,0 +1,1 @@
+#shellcheck shell=sh

--- a/lib/array/subjects.sh
+++ b/lib/array/subjects.sh
@@ -1,0 +1,3 @@
+#shellcheck shell=sh
+
+shellspec_import 'array/subjects/array'

--- a/lib/array/subjects/array.sh
+++ b/lib/array/subjects/array.sh
@@ -1,0 +1,19 @@
+#shellcheck shell=sh
+
+shellspec_syntax 'shellspec_subject_array'
+
+shellspec_subject_array() {
+  # next word in DSL should be the array name
+  shellspec_syntax_param count [ $# -ge 1 ] || return 0
+
+  # shellcheck disable=SC2034
+  SHELLSPEC_META="array:$1"
+  if eval "[ \${$1+x} ] &&:"; then # array is set
+    shellspec_copy_array "$1" "SHELLSPEC_SUBJECT"
+  else
+    unset SHELLSPEC_SUBJECT ||:
+  fi
+  shift
+
+  eval shellspec_syntax_dispatch modifier ${1+'"$@"'}
+}

--- a/lib/array/utils.sh
+++ b/lib/array/utils.sh
@@ -1,0 +1,9 @@
+#shellcheck shell=sh
+
+shellspec_copy_array() {
+    # $1: from array name
+    # $2: to array name
+    # eval sees: to_array=("${from_array[@]")
+    #    ____#######____########
+    eval "$2"'=("${'"$1"'[@]}")'
+}


### PR DESCRIPTION
First steps towards implementing array support (#177). This PR is far from complete but this way @ko1nksm can give early feedback.

I suggest we create a new branch to develop this feature until it is ready for the master branch.

Done so far:

- [x] Created the folder structure as suggested
- [x] Implemented `array` subject
- [x] Implemented `be size <n>` matcher
- [x] Created `examples-array` folder (which I'll use to run experiments for the time being)   