### PR TITLE
More fluently-readable "exist" matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1320,7 +1320,7 @@ End
 The hooks may fail in subtle ways if there is output to stderr, even if the 
 return code / exit code is `0`.  
 
-Commands like `git checkout` routinely write to stdout, even if there was no actual 
+Commands like `git checkout` routinely write to stderr, even if there was no actual 
 failure, so be aware that your hooks may fail because of this. 
 
 ### Helpers

--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,7 @@ Describe 'Path helper'
   Path hosts-file="/etc/hosts"
 
   It 'defines short alias for long path'
-    The path hosts-file should be exists
+    The path hosts-file should be existent
   End
 End
 ```
@@ -1636,7 +1636,7 @@ Describe "Support commands example"
   It "touch a file"
     When run touch "file"
     The output should eq "file was touched"
-    The file "file" should be exist
+    The file "file" should be existent
   End
 End
 ```

--- a/docs/references.md
+++ b/docs/references.md
@@ -291,7 +291,7 @@ The word 1 should equal foo # stdout omitted
 
 ```sh
 Path data-file=/tmp/data.txt
-The path data-file should be exist
+The path data-file should be existent
 ```
 
 #### `function` subject
@@ -419,7 +419,7 @@ the subject expected file path
 
 | Matcher             | Description                                 |
 | :------------------ | :------------------------------------------ |
-| be exist            | The file should exist.                      |
+| be existent         | The file should exist.                      |
 | be file             | The file should be a file.                  |
 | be directory        | The file should be a directory.             |
 | be empty file       | The file should be an empty file.           |
@@ -435,7 +435,13 @@ the subject expected file path
 | has setgid          | The file should have the setgid flag set.   |
 | has setuid          | The file should have the setuid flag set.   |
 
-##### `be exist` matcher
+##### `be existent` matcher
+
+```sh
+The path /target/path should be existent
+```
+
+or 
 
 ```sh
 The path /target/path should be exist

--- a/docs/test.md
+++ b/docs/test.md
@@ -4,7 +4,7 @@
 
 Use `contrib/all.sh` to test on all installed shells.
 
-Usage: `contrib/all.sh [COMMNAD (shellspec and etc)]`
+Usage: `contrib/all.sh [COMMAND (shellspec and etc)]`
 
 ## contrib/test_in_docker.sh
 

--- a/examples/spec/11.matcher_spec.sh
+++ b/examples/spec/11.matcher_spec.sh
@@ -20,9 +20,9 @@ Describe 'matcher example'
   End
 
   Describe 'stat matchers'
-    Describe 'be exist'
-      It 'checks if path is exist'
-        The path 'data.txt' should be exist
+    Describe 'be existent'
+      It 'checks if path exists'
+        The path 'data.txt' should be existent
       End
 
       It 'checks if path is file'

--- a/lib/core/matchers/be/stat.sh
+++ b/lib/core/matchers/be/stat.sh
@@ -1,6 +1,7 @@
 #shellcheck shell=sh disable=SC2016
 
 shellspec_syntax 'shellspec_matcher_be_exist'
+shellspec_syntax 'shellspec_matcher_be_existent'
 shellspec_syntax 'shellspec_matcher_be_file'
 shellspec_syntax 'shellspec_matcher_be_directory'
 
@@ -37,6 +38,7 @@ shellspec_make_file_matcher() {
 }
 
 shellspec_make_file_matcher exist            "-e" "exists" "does not exist"
+shellspec_make_file_matcher existent         "-e" "exists" "does not exist"
 shellspec_make_file_matcher file             "-f" "is a regular file"
 shellspec_make_file_matcher directory        "-d" "is a directory"
 

--- a/spec/core/matchers/be/stat_spec.sh
+++ b/spec/core/matchers/be/stat_spec.sh
@@ -8,6 +8,31 @@ Describe "core/matchers/be/stat.sh"
   not_exist() { [ ! -e "$FIXTURE/$1" ]; }
   check_root() { [ "$(@id -u)" = 0 ]; }
 
+  Describe 'be existent matcher'
+    Example 'example'
+      Path exist-file="$FIXTURE/exist"
+      The path exist-file should be existent
+    End
+
+    It 'matches when path exists'
+      subject() { %- "$FIXTURE/exist"; }
+      When run shellspec_matcher_be_existent
+      The status should be success
+    End
+
+    It 'does not match when path does not exist'
+      subject() { %- "$FIXTURE/exist.not-exists"; }
+      When run shellspec_matcher_be_existent
+      The status should be failure
+    End
+
+    It 'outputs error if parameters count is invalid'
+      subject() { %- "$FIXTURE/exist"; }
+      When run shellspec_matcher_be_existent foo
+      The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
+    End
+  End
+
   Describe 'be exist matcher'
     Example 'example'
       Path exist-file="$FIXTURE/exist"

--- a/spec/install_spec.sh
+++ b/spec/install_spec.sh
@@ -130,7 +130,7 @@ Describe "./install.sh"
 
       It 'fetchs archive'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/curl"
-        The file "$TMPBASE/curl/README.md" should be exist
+        The file "$TMPBASE/curl/README.md" should be existent
         The stderr should be defined # ignore stderr
       End
     End
@@ -146,7 +146,7 @@ Describe "./install.sh"
 
       It 'fetchs archive'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/wget"
-        The file "$TMPBASE/wget/README.md" should be exist
+        The file "$TMPBASE/wget/README.md" should be existent
         The stderr should be defined # ignore stderr
       End
     End
@@ -158,7 +158,7 @@ Describe "./install.sh"
 
       It 'does not create directory'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/error"
-        The directory "$TMPBASE/error" should not be exist
+        The directory "$TMPBASE/error" should not be existent
         The status should be failure
       End
     End

--- a/spec/libexec/runner_spec.sh
+++ b/spec/libexec/runner_spec.sh
@@ -58,7 +58,7 @@ Describe "libexec/runner.sh"
       Path tempdir="$dir"
       When call rmtempdir "$dir"
       The status should be success
-      The path tempdir should not be exist
+      The path tempdir should not be existent
     End
   End
 

--- a/spec/shellspec-gen-bin_spec.sh
+++ b/spec/shellspec-gen-bin_spec.sh
@@ -36,7 +36,7 @@ Describe "run shellspec-gen-bin.sh"
     It 'raises error'
       When run source ./libexec/shellspec-gen-bin.sh "@dummy"
       The error should eq "shellspec helper directory not found: $HELPERDIR"
-      The file dummy-bin should not be exist
+      The file dummy-bin should not be existent
       The status should be failure
     End
   End
@@ -52,7 +52,7 @@ Describe "run shellspec-gen-bin.sh"
     It 'skips generate support bin'
       When run source ./libexec/shellspec-gen-bin.sh "@dummy"
       The error should start with "Skip, @dummy already exist"
-      The file dummy-bin should be exist
+      The file dummy-bin should be existent
     End
   End
 End


### PR DESCRIPTION
I'm working a lot with technical writers, lately. 
They suggest that the "[path] be exist" matcher be renamed, so that the behavior-driven code can be read more fluently.

Given the constraints of the formal syntax, "[path] exists" may be too far off (at least, for my skills as a contributor), so I'm suggesting "[path] be existent".

In the Java world, I have worked with developers who are really perfectionist about fluent APIs (in Java, stuff like `.matches(aRegex).and().isANumber()`), there are definitely the kind of programmers who appreciate this :) 

My colleague pointed out that I should make this clear: I do not mean this to be a condescending thing to point out grammar issues, and I hope that's not how it comes across.  
Personally, I'm using this ticket as motivation to dig a bit into the shellspec code, ... and to fix a typo I submitted recently :sweat_smile:  (that one off-ticket commit in there - I hope you don't mind).

----

What I tested locally: I ran this, and it worked without test failures. 
```
$ ./contrib/all.sh ./shellspec
Linux dev-106 5.11.0-17-generic #18-Ubuntu SMP Thu May 6 20:10:11 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
==================================================
      sh : /usr/bin/sh -> /usr/bin/dash
     ash : ----
    dash : /usr/bin/dash
    bash : /usr/bin/bash
     zsh : /usr/bin/zsh
   pdksh : ----
     ksh : ----
   ksh93 : ----
    mksh : ----
    oksh : ----
    yash : ----
    posh : ----
 busybox : /usr/bin/busybox
==================================================
[...]
```

