### PR TITLE
More fluent exist matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,7 @@ Describe 'Path helper'
   Path hosts-file="/etc/hosts"
 
   It 'defines short alias for long path'
-    The path hosts-file should be existent
+    The path hosts-file should exist
   End
 End
 ```
@@ -1636,7 +1636,7 @@ Describe "Support commands example"
   It "touch a file"
     When run touch "file"
     The output should eq "file was touched"
-    The file "file" should be existent
+    The file "file" should exist
   End
 End
 ```

--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,7 @@ Describe 'Path helper'
   Path hosts-file="/etc/hosts"
 
   It 'defines short alias for long path'
-    The path hosts-file should be exists
+    The path hosts-file should be existent
   End
 End
 ```
@@ -1636,7 +1636,7 @@ Describe "Support commands example"
   It "touch a file"
     When run touch "file"
     The output should eq "file was touched"
-    The file "file" should be exist
+    The file "file" should be existent
   End
 End
 ```

--- a/docs/references.md
+++ b/docs/references.md
@@ -420,6 +420,7 @@ the subject expected file path
 | Matcher             | Description                                 |
 | :------------------ | :------------------------------------------ |
 | exist               | The file should exist.                      |
+| ~~be exist~~        | The file should exist. (deprecated)         |
 | be file             | The file should be a file.                  |
 | be directory        | The file should be a directory.             |
 | be empty file       | The file should be an empty file.           |

--- a/docs/references.md
+++ b/docs/references.md
@@ -291,7 +291,7 @@ The word 1 should equal foo # stdout omitted
 
 ```sh
 Path data-file=/tmp/data.txt
-The path data-file should be exist
+The path data-file should be existent
 ```
 
 #### `function` subject
@@ -419,7 +419,7 @@ the subject expected file path
 
 | Matcher             | Description                                 |
 | :------------------ | :------------------------------------------ |
-| be exist            | The file should exist.                      |
+| be existent         | The file should exist.                      |
 | be file             | The file should be a file.                  |
 | be directory        | The file should be a directory.             |
 | be empty file       | The file should be an empty file.           |
@@ -435,7 +435,13 @@ the subject expected file path
 | has setgid          | The file should have the setgid flag set.   |
 | has setuid          | The file should have the setuid flag set.   |
 
-##### `be exist` matcher
+##### `be existent` matcher
+
+```sh
+The path /target/path should be existent
+```
+
+or 
 
 ```sh
 The path /target/path should be exist

--- a/docs/references.md
+++ b/docs/references.md
@@ -291,7 +291,7 @@ The word 1 should equal foo # stdout omitted
 
 ```sh
 Path data-file=/tmp/data.txt
-The path data-file should be existent
+The path data-file should exist
 ```
 
 #### `function` subject
@@ -419,7 +419,7 @@ the subject expected file path
 
 | Matcher             | Description                                 |
 | :------------------ | :------------------------------------------ |
-| be existent         | The file should exist.                      |
+| exist               | The file should exist.                      |
 | be file             | The file should be a file.                  |
 | be directory        | The file should be a directory.             |
 | be empty file       | The file should be an empty file.           |
@@ -435,10 +435,10 @@ the subject expected file path
 | has setgid          | The file should have the setgid flag set.   |
 | has setuid          | The file should have the setuid flag set.   |
 
-##### `be existent` matcher
+##### `exist` matcher
 
 ```sh
-The path /target/path should be existent
+The path /target/path should exist
 ```
 
 or 

--- a/examples/spec/11.matcher_spec.sh
+++ b/examples/spec/11.matcher_spec.sh
@@ -20,9 +20,9 @@ Describe 'matcher example'
   End
 
   Describe 'stat matchers'
-    Describe 'be exist'
-      It 'checks if path is exist'
-        The path 'data.txt' should be exist
+    Describe 'be existent'
+      It 'checks if path exists'
+        The path 'data.txt' should be existent
       End
 
       It 'checks if path is file'

--- a/examples/spec/11.matcher_spec.sh
+++ b/examples/spec/11.matcher_spec.sh
@@ -20,9 +20,9 @@ Describe 'matcher example'
   End
 
   Describe 'stat matchers'
-    Describe 'be existent'
+    Describe 'exists'
       It 'checks if path exists'
-        The path 'data.txt' should be existent
+        The path 'data.txt' should exist
       End
 
       It 'checks if path is file'

--- a/lib/core/matchers.sh
+++ b/lib/core/matchers.sh
@@ -64,6 +64,7 @@ shellspec_get_failure_message() {
 shellspec_import 'core/matchers/be'
 shellspec_import 'core/matchers/end_with'
 shellspec_import 'core/matchers/equal'
+shellspec_import 'core/matchers/exist'
 shellspec_import 'core/matchers/has'
 shellspec_import 'core/matchers/include'
 shellspec_import 'core/matchers/match'

--- a/lib/core/matchers/be/stat.sh
+++ b/lib/core/matchers/be/stat.sh
@@ -1,6 +1,7 @@
 #shellcheck shell=sh disable=SC2016
 
 shellspec_syntax 'shellspec_matcher_be_exist'
+shellspec_syntax 'shellspec_matcher_be_existent'
 shellspec_syntax 'shellspec_matcher_be_file'
 shellspec_syntax 'shellspec_matcher_be_directory'
 
@@ -37,6 +38,7 @@ shellspec_make_file_matcher() {
 }
 
 shellspec_make_file_matcher exist            "-e" "exists" "does not exist"
+shellspec_make_file_matcher existent         "-e" "exists" "does not exist"
 shellspec_make_file_matcher file             "-f" "is a regular file"
 shellspec_make_file_matcher directory        "-d" "is a directory"
 

--- a/lib/core/matchers/be/stat.sh
+++ b/lib/core/matchers/be/stat.sh
@@ -1,7 +1,6 @@
 #shellcheck shell=sh disable=SC2016
 
 shellspec_syntax 'shellspec_matcher_be_exist'
-shellspec_syntax 'shellspec_matcher_be_existent'
 shellspec_syntax 'shellspec_matcher_be_file'
 shellspec_syntax 'shellspec_matcher_be_directory'
 
@@ -37,8 +36,8 @@ shellspec_make_file_matcher() {
   eval "$SHELLSPEC_EVAL"
 }
 
+# deprecated, should use "file should exist" instead
 shellspec_make_file_matcher exist            "-e" "exists" "does not exist"
-shellspec_make_file_matcher existent         "-e" "exists" "does not exist"
 shellspec_make_file_matcher file             "-f" "is a regular file"
 shellspec_make_file_matcher directory        "-d" "is a directory"
 

--- a/lib/core/matchers/exist.sh
+++ b/lib/core/matchers/exist.sh
@@ -7,9 +7,9 @@ shellspec_matcher_exist() {
   }
 
   shellspec_syntax_failure_message + \
-    'expected $2 to exist'
+    'expected $1 to exist'
   shellspec_syntax_failure_message - \
-    'did not expect $2 to exist'
+    'did not expect $1 to exist'
 
   shellspec_syntax_param count [ $# -eq 0 ] || return 0
   shellspec_matcher_do_match "$@"

--- a/lib/core/matchers/exist.sh
+++ b/lib/core/matchers/exist.sh
@@ -7,9 +7,9 @@ shellspec_matcher_exist() {
   }
 
   shellspec_syntax_failure_message + \
-    'expected file $2 to exist'
+    'expected $2 to exist'
   shellspec_syntax_failure_message - \
-    'did not expect file $2 to exist'
+    'did not expect $2 to exist'
 
   shellspec_syntax_param count [ $# -eq 0 ] || return 0
   shellspec_matcher_do_match "$@"

--- a/lib/core/matchers/exist.sh
+++ b/lib/core/matchers/exist.sh
@@ -3,7 +3,6 @@ shellspec_syntax 'shellspec_matcher_exist'
 shellspec_matcher_exist() {
   shellspec_matcher__match() {
     [ -e "${SHELLSPEC_SUBJECT:-}" ]
-    return 0
   }
 
   shellspec_syntax_failure_message + \

--- a/lib/core/matchers/exist.sh
+++ b/lib/core/matchers/exist.sh
@@ -1,0 +1,16 @@
+shellspec_syntax 'shellspec_matcher_exist'
+
+shellspec_matcher_exist() {
+  shellspec_matcher__match() {
+    [ -e "${SHELLSPEC_SUBJECT:-}" ]
+    return 0
+  }
+
+  shellspec_syntax_failure_message + \
+    'expected file $2 to exist'
+  shellspec_syntax_failure_message - \
+    'did not expect file $2 to exist'
+
+  shellspec_syntax_param count [ $# -eq 0 ] || return 0
+  shellspec_matcher_do_match "$@"
+}

--- a/lib/core/matchers/exist.sh
+++ b/lib/core/matchers/exist.sh
@@ -11,5 +11,5 @@ shellspec_matcher_exist() {
     'did not expect $1 to exist'
 
   shellspec_syntax_param count [ $# -eq 0 ] || return 0
-  shellspec_matcher_do_match "$@"
+  shellspec_matcher_do_match
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lib/core/matchers/be/variable.sh",
     "lib/core/matchers/end_with.sh",
     "lib/core/matchers/equal.sh",
+    "lib/core/matchers/exist.sh",
     "lib/core/matchers/has.sh",
     "lib/core/matchers/has/stat.sh",
     "lib/core/matchers/include.sh",

--- a/spec/core/matchers/be/stat_spec.sh
+++ b/spec/core/matchers/be/stat_spec.sh
@@ -28,7 +28,7 @@ Describe "core/matchers/be/stat.sh"
 
     It 'outputs error if parameters count is invalid'
       subject() { %- "$FIXTURE/exist"; }
-      When run shellspec_matcher_be_existent foo
+      When run shellspec_matcher_exist foo
       The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
     End
   End

--- a/spec/core/matchers/be/stat_spec.sh
+++ b/spec/core/matchers/be/stat_spec.sh
@@ -8,6 +8,31 @@ Describe "core/matchers/be/stat.sh"
   not_exist() { [ ! -e "$FIXTURE/$1" ]; }
   check_root() { [ "$(@id -u)" = 0 ]; }
 
+  Describe 'be existent matcher'
+    Example 'example'
+      Path exist-file="$FIXTURE/exist"
+      The path exist-file should be existent
+    End
+
+    It 'matches when path exists'
+      subject() { %- "$FIXTURE/exist"; }
+      When run shellspec_matcher_be_existent
+      The status should be success
+    End
+
+    It 'does not match when path does not exist'
+      subject() { %- "$FIXTURE/exist.not-exists"; }
+      When run shellspec_matcher_be_existent
+      The status should be failure
+    End
+
+    It 'outputs error if parameters count is invalid'
+      subject() { %- "$FIXTURE/exist"; }
+      When run shellspec_matcher_be_existent foo
+      The stderr should equal SYNTAX_ERROR_WRONG_PARAMETER_COUNT
+    End
+  End
+
   Describe 'be exist matcher'
     Example 'example'
       Path exist-file="$FIXTURE/exist"

--- a/spec/core/matchers/be/stat_spec.sh
+++ b/spec/core/matchers/be/stat_spec.sh
@@ -8,21 +8,21 @@ Describe "core/matchers/be/stat.sh"
   not_exist() { [ ! -e "$FIXTURE/$1" ]; }
   check_root() { [ "$(@id -u)" = 0 ]; }
 
-  Describe 'be existent matcher'
+  Describe 'exist matcher'
     Example 'example'
       Path exist-file="$FIXTURE/exist"
-      The path exist-file should be existent
+      The path exist-file should exist
     End
 
     It 'matches when path exists'
       subject() { %- "$FIXTURE/exist"; }
-      When run shellspec_matcher_be_existent
+      When run shellspec_matcher_exist
       The status should be success
     End
 
     It 'does not match when path does not exist'
       subject() { %- "$FIXTURE/exist.not-exists"; }
-      When run shellspec_matcher_be_existent
+      When run shellspec_matcher_exist
       The status should be failure
     End
 

--- a/spec/install_spec.sh
+++ b/spec/install_spec.sh
@@ -130,7 +130,7 @@ Describe "./install.sh"
 
       It 'fetchs archive'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/curl"
-        The file "$TMPBASE/curl/README.md" should be exist
+        The file "$TMPBASE/curl/README.md" should be existent
         The stderr should be defined # ignore stderr
       End
     End
@@ -146,7 +146,7 @@ Describe "./install.sh"
 
       It 'fetchs archive'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/wget"
-        The file "$TMPBASE/wget/README.md" should be exist
+        The file "$TMPBASE/wget/README.md" should be existent
         The stderr should be defined # ignore stderr
       End
     End
@@ -158,7 +158,7 @@ Describe "./install.sh"
 
       It 'does not create directory'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/error"
-        The directory "$TMPBASE/error" should not be exist
+        The directory "$TMPBASE/error" should not be existent
         The status should be failure
       End
     End

--- a/spec/install_spec.sh
+++ b/spec/install_spec.sh
@@ -130,7 +130,7 @@ Describe "./install.sh"
 
       It 'fetchs archive'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/curl"
-        The file "$TMPBASE/curl/README.md" should be existent
+        The file "$TMPBASE/curl/README.md" should exist
         The stderr should be defined # ignore stderr
       End
     End
@@ -146,7 +146,7 @@ Describe "./install.sh"
 
       It 'fetchs archive'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/wget"
-        The file "$TMPBASE/wget/README.md" should be existent
+        The file "$TMPBASE/wget/README.md" should exist
         The stderr should be defined # ignore stderr
       End
     End
@@ -158,7 +158,7 @@ Describe "./install.sh"
 
       It 'does not create directory'
         When call fetch "http://repo.test/b3d5591.tar.gz" "$TMPBASE/error"
-        The directory "$TMPBASE/error" should not be existent
+        The directory "$TMPBASE/error" should not exist
         The status should be failure
       End
     End

--- a/spec/libexec/runner_spec.sh
+++ b/spec/libexec/runner_spec.sh
@@ -58,7 +58,7 @@ Describe "libexec/runner.sh"
       Path tempdir="$dir"
       When call rmtempdir "$dir"
       The status should be success
-      The path tempdir should not be existent
+      The path tempdir should not exist
     End
   End
 

--- a/spec/libexec/runner_spec.sh
+++ b/spec/libexec/runner_spec.sh
@@ -58,7 +58,7 @@ Describe "libexec/runner.sh"
       Path tempdir="$dir"
       When call rmtempdir "$dir"
       The status should be success
-      The path tempdir should not be exist
+      The path tempdir should not be existent
     End
   End
 

--- a/spec/shellspec-gen-bin_spec.sh
+++ b/spec/shellspec-gen-bin_spec.sh
@@ -36,7 +36,7 @@ Describe "run shellspec-gen-bin.sh"
     It 'raises error'
       When run source ./libexec/shellspec-gen-bin.sh "@dummy"
       The error should eq "shellspec helper directory not found: $HELPERDIR"
-      The file dummy-bin should not be existent
+      The file dummy-bin should not exist
       The status should be failure
     End
   End
@@ -52,7 +52,7 @@ Describe "run shellspec-gen-bin.sh"
     It 'skips generate support bin'
       When run source ./libexec/shellspec-gen-bin.sh "@dummy"
       The error should start with "Skip, @dummy already exist"
-      The file dummy-bin should be existent
+      The file dummy-bin should exist
     End
   End
 End

--- a/spec/shellspec-gen-bin_spec.sh
+++ b/spec/shellspec-gen-bin_spec.sh
@@ -36,7 +36,7 @@ Describe "run shellspec-gen-bin.sh"
     It 'raises error'
       When run source ./libexec/shellspec-gen-bin.sh "@dummy"
       The error should eq "shellspec helper directory not found: $HELPERDIR"
-      The file dummy-bin should not be exist
+      The file dummy-bin should not be existent
       The status should be failure
     End
   End
@@ -52,7 +52,7 @@ Describe "run shellspec-gen-bin.sh"
     It 'skips generate support bin'
       When run source ./libexec/shellspec-gen-bin.sh "@dummy"
       The error should start with "Skip, @dummy already exist"
-      The file dummy-bin should be exist
+      The file dummy-bin should be existent
     End
   End
 End


### PR DESCRIPTION
Continuing where https://github.com/shellspec/shellspec/pull/220 left off.
Relates to discussion https://github.com/shellspec/shellspec/discussions/221

----

Disclaimer: **I'm not 100% sure what I'm doing in all cases here.**   
My implementation is mostly copy-paste-adjust, I don't understand the big picture as well as I like, yet.  
Here's hoping I can still fix all test cases.

----

**Draft status:** 
- [x] :x: fix failing tests 
<details>

```
$ TARGET=bash ./contrib/all.sh ./shellspec
# [...]
----------------------------------------------------------------------------
Running: /usr/bin/bash [bash 5.1.4(1)-release]
................................................................................................................................................................................................................................................................................................................................................................................................................................................ssssssssssssssssssssssssssssssss........................................................................ssssssss...................................................................................................................................s.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F...........................................................................................................................................................................F.........................................................................................................................................................................................................................................................................................F.......................
# [...]
  12) ./install.sh fetch() when can not fetch file does not create directory
      When call fetch http://repo.test/b3d5591.tar.gz /tmp/shellspec.1627736403.27218/install/error

      12.1) The directory /tmp/shellspec.1627736403.27218/install/error should not exist

              did not expect "/tmp/shellspec.1627736403.27218/install/error" to exist

            # spec/install_spec.sh:161

  13) libexec/runner.sh rmtempdir() deletes tempdir
      When call rmtempdir /tmp/shellspec.1627736403.27218/rmtempdir_test

      13.1) The path tempdir should not exist

              did not expect "/tmp/shellspec.1627736403.27218/rmtempdir_test" to exist

            # spec/libexec/runner_spec.sh:61

  14) run shellspec-gen-bin.sh when spec directory not exists raises error
      When run source ./libexec/shellspec-gen-bin.sh @dummy

      14.1) The file dummy-bin should not exist

              did not expect "/tmp/shellspec.1627736403.27218/gen-bin/spec/support/bin/@dummy" to exist

            # spec/shellspec-gen-bin_spec.sh:39

Finished in 66.24 seconds (user 67.61 seconds, sys 16.25 seconds)
1687 examples, 3 failures, 41 skips (muted 30 skips)
```

</details>

- [x] Address TODO comments