### PR TITLE
Avoid broken BusyBox-w32 4264.0

### DIFF
--- a/.github/workflows/windows-busybox.yml
+++ b/.github/workflows/windows-busybox.yml
@@ -23,6 +23,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-      - run: choco install -y --no-progress busybox
+      - run: choco install -y --no-progress busybox --version=3902.0
       - run: busybox ${{ matrix.shells.shell }} ./shellspec --task fixture:stat:prepare
       - run: busybox ${{ matrix.shells.shell }} ./shellspec


### PR DESCRIPTION
This is due to a bug in the upstream BusyBox.
https://bugs.busybox.net/show_bug.cgi?id=14061