### PR TITLE
Allow use of FD higher than 9

### DIFF
--- a/lib/core/dsl.sh
+++ b/lib/core/dsl.sh
@@ -288,7 +288,7 @@ shellspec_fds_check() {
   set -- "$SHELLSPEC_USE_FDS:"
   while [ "${1%%:*}" ]; do
     set -- "${1#*:}" "${1%%:*}"
-    case $2 in ([0-9]) continue; esac
+    case $2 in ([0-9]*) continue; esac
     if shellspec_is_identifier "$2"; then
       [ "$SHELLSPEC_FDVAR_AVAILABLE" ] && continue
       set -- "Assigning file descriptors to variables is not supported" \

--- a/lib/core/file_descriptor.sh
+++ b/lib/core/file_descriptor.sh
@@ -12,7 +12,7 @@ shellspec_open_file_descriptors() {
   set -- "$1:"
   while [ "${1%%:*}" ]; do
     set -- "${1#*:}" "${1%%:*}"
-    case $2 in ([0-9])
+    case $2 in ([0-9]*)
       shellspec_open_file_descriptor "$2" "$SHELLSPEC_STDIO_FILE_BASE.fd-$2"
       continue
     esac
@@ -31,7 +31,7 @@ shellspec_close_file_descriptors() {
   set -- "$1:"
   while [ "${1%%:*}" ]; do
     set -- "${1#*:}" "${1%%:*}"
-    case $2 in ([0-9])
+    case $2 in ([0-9]*)
       shellspec_close_file_descriptor "$2"
       continue
     esac


### PR DESCRIPTION
Hello,

I'm using fds 98/99 to be fairly high and not disturb scripts using my library.
When doing tests with:
```
UseFD 98
It "Emits a warning if an element is invalid"
    When call ammString::ExpandIntegerList "7-10,11,12,a-f,14-16"
    The fd 98 should include "is not an integer"
    The output should eq "7 8 9 10 11 12 14 15 16 "
End
```
It gave me errors:
```
Examples:
  1) string.lib: pattern matching: ammString::Contains returns success if a simple string is contained in another
     1.1) ERROR: UseFD: Invalid file descriptor: 98
```

I fixed it with a wildcard after the number to avoid ugly repetition of `[0-9]|[0-9][0-9]| ... ` as we can have more than 20 numbers (max_files is an `unsigned long` in struct files_stat_struct` of file `linux/include/uapi/linux/fs.h` )

Maybe you'll want to use an helper like "isInt" which is something like `[[ -n "${1//[0-9]/}" ]]`  but I'm not sure on how you'll want it used.

Just to know, is a new release planned soon ?

Thanks a lot !
Adrien