### PR TITLE
Makefile: Relocate BINDIR and LIBDIR under DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX ?= /usr/local
-BINDIR := $(PREFIX)/bin
-LIBDIR := $(PREFIX)/lib
+BINDIR := $(DESTDIR)$(PREFIX)/bin
+LIBDIR := $(DESTDIR)$(PREFIX)/lib
 
 GETOPTIONSCLI := getoptions-cli --indent=2 --shellcheck
 OPTPARSERDIR := lib/libexec/optparser


### PR DESCRIPTION
`DESTDIR` is a standard variable defined by most distributions while building Makefile packages and is expected to point to the "fake" package root directory.

Without this the installed files will be located in the wrong place (build chroot) on distributions packaging without using fakeroot for example.

Functionality remains unchanged for situations where `DESTDIR` happens to not be defined.