### PR TITLE
Small bug fix in example for #236 and more.

### DIFF
--- a/contrib/demo/mylib.sh
+++ b/contrib/demo/mylib.sh
@@ -1,5 +1,5 @@
 add() {
-  echo $(($1 * $2)) # bug: should be '+'
+  echo $(($1 + $2))
 }
 
 sub() {

--- a/examples/spec/07.before_after_hook_spec.sh
+++ b/examples/spec/07.before_after_hook_spec.sh
@@ -67,7 +67,7 @@ Describe 'before / after hook example'
 
   Describe '5: after hook'
     cleanup() { :; } # clean up something
-    Before 'cleanup'
+    After 'cleanup'
 
     It 'is called after execute example'
       When call echo ok


### PR DESCRIPTION
This PR is a modification for the sample code, not to the ShellSpec itself.
I fixed two bugs that are like typo. One of the modification is to Issue #236.
The other was marked and commented as a bug in the code.

After the modification, the test results are as follows.
- Before
``` Before.sh
$ pwd
/home/nao/Desktop/shellspec/contrib/demo
$ shellspec 
Running: /bin/sh [sh]
.F

Examples:
  1) example add() function performs addition
     When call add 2 3

     1.1) The output should eq 5

            expected: 5
                 got: 6

          # spec/demo_spec.sh:14

Finished in 0.07 seconds (user 0.04 seconds, sys 0.00 seconds)
2 examples, 1 failure


Failure examples / Errors: (Listed here affect your suite's status)

shellspec spec/demo_spec.sh:12 # 1) example add() function performs addition FAILED
```

- After
```　After.sh
$ shellspec 
Running: /bin/sh [sh]
..

Finished in 0.03 seconds (user 0.02 seconds, sys 0.01 seconds)
2 examples, 0 failures
```