### PR TITLE
fix: Added support for comma (`,`) as decimal separator - Fix #274

### DIFF
--- a/lib/libexec/reporter.sh
+++ b/lib/libexec/reporter.sh
@@ -22,7 +22,7 @@ read_time_log() {
   # shellcheck disable=SC2034
   while IFS= read -r line; do
     case $line in (real[\ $TAB]*|user[\ $TAB]*|sys[\ $TAB]*)
-      case ${line##*[ $TAB]} in (*[!0-9.]*) continue; esac
+      case ${line##*[ $TAB]} in (*[!0-9.,]*) continue; esac
       eval "$1_${line%%[ $TAB]*}=\"\${line##*[ \$TAB]}\""
     esac
   done < "$2" &&:


### PR DESCRIPTION
The **`--profiler` option** now works on locales which had the decimal separator set as comma (`,`) and not period (`.`), such as **Italian, Spanish, French** and many others.

See [my answers](https://github.com/shellspec/shellspec/issues/274#issuecomment-1311636524) on issue #274 for more info on the subject.

@ko1nksm This shouldn't be a problem, but i could test this solution **only** on **Bash**. 
It would be great if you could run the tests for the other shells too. 😃