### PR TITLE
lib/core/evaluation.sh: trim spaces between `#!` and the command

### DIFF
--- a/lib/core/evaluation.sh
+++ b/lib/core/evaluation.sh
@@ -139,12 +139,20 @@ shellspec_evaluation_run_instruction() {
 
 shellspec_shebang_arguments() {
   read -r line
+  # Trim spaces between `#!` and the command.
+  case $line in (\#!\ *)
+    shellspec_trim line "${line#* }"
+    line="#!$line"
+  esac
+  # Trim `env` call.
   case $line in (\#!/usr/bin/env\ * | \#!/bin/env\ *)
     shellspec_trim line "${line#* }"
     line="#!$line"
   esac
+  # Trim line if shebang.
   case $line in (\#!*)
     shellspec_trim line "$line"
+    # Get shebang arguments.
     case $line in (*\ *)
       shellspec_trim line "${line#* }"
       shellspec_putsn "$line"

--- a/spec/core/evaluation_spec.sh
+++ b/spec/core/evaluation_spec.sh
@@ -365,6 +365,14 @@ Describe "core/evaluation.sh"
           "/bin/sh -u"              ""
           "#!/usr/bin/env bash"     ""
           "#!/bin/env bash"         ""
+
+          "#! /usr/bin/env bash"    ""
+          "#! /bin/env bash"        ""
+          "#! /bin/sh -u"           "-u"
+          "#! /bin/sh   -u -u  "    "-u -u"
+          "#! /bin/sh          "    ""
+          "#! /usr/bin/env bash"    ""
+          "#! /bin/env bash"        ""
         End
 
         shebang_arguments() {


### PR DESCRIPTION
This commit tries to fix `When run script` evaluation for scripts having spaces between `#!` and the command in their shebang, e.g. `#! /usr/bin/env bash`.

This commit also updates the associated unit test.

Indeed, the `shellspec_shebang_arguments()` function has not been trying to trim these spaces before.

---

I've tried to respect coding conventions, but I'm not sure about the quality of the result and wait for reviews.