### PR TITLE
fix coverage of files included with a relative path

### DIFF
--- a/lib/core/dsl.sh
+++ b/lib/core/dsl.sh
@@ -64,28 +64,6 @@ shellspec_begin() {
   shellspec_output BEGIN
 }
 
-shellspec_execdir() {
-  case $1 in
-    @project | @project/*) set -- "${1#@project}" ;;
-    @basedir | @basedir/*)
-      set -- "$1" "/${SHELLSPEC_SPECFILE%/*}"
-      while [ "$2" ]; do
-        [ -e "${SHELLSPEC_PROJECT_ROOT%/}/$2/.shellspec" ] && break
-        [ -e "${SHELLSPEC_PROJECT_ROOT%/}/$2/.shellspec-basedir" ] && break
-        set -- "$1" "${2%/*}"
-      done
-      set -- "${2#/}${1#@basedir}"
-      ;;
-    @specfile | @specfile/*) set -- "${SHELLSPEC_SPECFILE%/*}${1#@specfile}" ;;
-    *) set -- ""
-  esac
-  case $1 in
-    /*) set -- "$1" ;;
-    ?*) set -- "/$1" ;;
-  esac
-  cd "${SHELLSPEC_PROJECT_ROOT%/}$1"
-}
-
 shellspec_perform() {
   SHELLSPEC_ENABLED=$1 SHELLSPEC_FILTER=$2
 }

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -942,6 +942,28 @@ shellspec_abspath_win() {
   eval "$1=\"\${$1#/}\""
 }
 
+shellspec_execdir() {
+  case $1 in
+    @project | @project/*) set -- "${1#@project}" ;;
+    @basedir | @basedir/*)
+      set -- "$1" "/${SHELLSPEC_SPECFILE%/*}"
+      while [ "$2" ]; do
+        [ -e "${SHELLSPEC_PROJECT_ROOT%/}/$2/.shellspec" ] && break
+        [ -e "${SHELLSPEC_PROJECT_ROOT%/}/$2/.shellspec-basedir" ] && break
+        set -- "$1" "${2%/*}"
+      done
+      set -- "${2#/}${1#@basedir}"
+      ;;
+    @specfile | @specfile/*) set -- "${SHELLSPEC_SPECFILE%/*}${1#@specfile}" ;;
+    *) set -- ""
+  esac
+  case $1 in
+    /*) set -- "$1" ;;
+    ?*) set -- "/$1" ;;
+  esac
+  cd "${SHELLSPEC_PROJECT_ROOT%/}$1"
+}
+
 shellspec_mv() { "$SHELLSPEC_MV" "$@"; }
 shellspec_rm() { "$SHELLSPEC_RM" "$@"; }
 shellspec_chmod() { "$SHELLSPEC_CHMOD" "$@"; }

--- a/lib/libexec/kcov-executor.sh
+++ b/lib/libexec/kcov-executor.sh
@@ -25,6 +25,8 @@ executor() {
 
   #shellcheck disable=SC2039,SC2086
   (
+    shellspec_execdir "${SHELLSPEC_EXECDIR}"
+
     "$SHELLSPEC_KCOV_PATH" \
     $SHELLSPEC_KCOV_COMMON_OPTS \
     $SHELLSPEC_KCOV_OPTS \


### PR DESCRIPTION
This pull request should close [this issue](https://github.com/shellspec/shellspec/issues/327/).

I'm totally not sure if the `shellspec_execdir()` moving yet respects the project hierarchy.

All tests passed and waiting for review!